### PR TITLE
Add cached ept reader

### DIFF
--- a/cachedept/CMakeLists.txt
+++ b/cachedept/CMakeLists.txt
@@ -1,0 +1,31 @@
+#
+# CachedEpt plugin CMake configuration
+#
+include(${PDAL_CMAKE_DIR}/tbb.cmake)
+if (NOT TBB_FOUND)
+    message(FATAL_ERROR "Can't find TBB support required.")
+endif()
+
+if (WIN32)
+    add_definitions(-DNOMINMAX)
+endif()
+
+#
+# EPT LRU-Cached Reader
+#
+PDAL_ADD_PLUGIN(reader_libname reader cachedept
+    FILES
+        io/CachedTileContents.cpp
+        io/CachedEptReader.cpp
+        io/private/ept/Addon.cpp
+        io/private/ept/Connector.cpp
+        io/private/ept/EptInfo.cpp
+        io/private/ept/FixedPointLayout.cpp
+        io/private/ept/TileContents.cpp
+    LINK_WITH
+        ${TBB_LIBRARIES}
+    INCLUDES
+        ${TBB_INCLUDE_DIR}
+        ${NLOHMANN_INCLUDE_DIR}
+        ${PDAL_VENDOR_DIR}
+)

--- a/cachedept/io/CachedEptReader.cpp
+++ b/cachedept/io/CachedEptReader.cpp
@@ -1,0 +1,912 @@
+/******************************************************************************
+ * Copyright (c) 2017, Connor Manning (connor@hobu.co)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include <limits>
+
+#include <nlohmann/json.hpp>
+
+#include <pdal/ArtifactManager.hpp>
+#include <pdal/Polygon.hpp>
+#include <pdal/SrsBounds.hpp>
+#include <pdal/pdal_features.hpp>
+#include <pdal/private/SrsTransform.hpp>
+#include <pdal/private/gdal/GDALUtils.hpp>
+#include <pdal/util/ThreadPool.hpp>
+
+#include "private/ept/Connector.hpp"
+#include "private/ept/EptArtifact.hpp"
+#include "private/ept/EptSupport.hpp"
+
+#include "CachedEptReader.hpp"
+#include "CachedTileContents.hpp"
+#include "private/thread-safe-lru/scalable-cache.h"
+#include "private/thread-safe-lru/string-key.h"
+
+namespace pdal
+{
+
+typedef tstarling::ThreadSafeStringKey String;
+typedef String::HashCompare HashCompare;
+typedef tstarling::ThreadSafeLRUCache<String, NL::json, HashCompare> JsonCache;
+
+std::unique_ptr<JsonCache> jsonCache =
+    std::unique_ptr<JsonCache>(new JsonCache(4194304));
+
+namespace
+{
+
+const PluginInfo s_info{"readers.lruept", "LRU Cached EPT Reader",
+                        "http://pdal.io/stages/reader.ept.html"};
+
+}
+
+CREATE_SHARED_STAGE(CachedEptReader, s_info)
+
+struct PolyXform
+{
+    Polygon poly;
+    SrsTransform xform;
+};
+
+struct BoxXform
+{
+    BOX3D box;
+    SrsTransform xform;
+};
+
+struct CachedEptReader::Args
+{
+public:
+    SrsBounds m_bounds;
+    std::string m_origin;
+    std::size_t m_threads = 0;
+    double m_resolution = 0;
+    std::vector<Polygon> m_polys;
+    NL::json m_addons;
+
+    NL::json m_query;
+    NL::json m_headers;
+    NL::json m_ogr;
+};
+
+struct CachedEptReader::Private
+{
+public:
+    std::unique_ptr<Connector> connector;
+    std::unique_ptr<EptInfo> info;
+    std::unique_ptr<ThreadPool> pool;
+    std::unique_ptr<CachedTileContents> currentTile;
+    std::unique_ptr<Hierarchy> hierarchy;
+    std::queue<CachedTileContents> contents;
+    AddonList addons;
+    std::mutex mutex;
+    std::condition_variable contentsCv;
+    std::vector<PolyXform> polys;
+    BoxXform bounds;
+};
+
+CachedEptReader::CachedEptReader()
+    : m_args(new CachedEptReader::Args), m_p(new CachedEptReader::Private),
+      m_artifactMgr(nullptr)
+{
+}
+
+CachedEptReader::~CachedEptReader() {}
+
+std::string CachedEptReader::getName() const
+{
+    return s_info.name;
+}
+
+void CachedEptReader::addArgs(ProgramArgs& args)
+{
+    args.add("bounds", "Bounds to fetch", m_args->m_bounds);
+    args.add("origin", "Origin of source file to fetch", m_args->m_origin);
+    args.add("requests", "Number of worker threads", m_args->m_threads,
+             (size_t)15);
+    args.addSynonym("requests", "threads");
+    args.add("resolution", "Resolution limit", m_args->m_resolution);
+    args.add("addons", "Mapping of addon dimensions to their output directory",
+             m_args->m_addons);
+    args.add("polygon", "Bounding polygon(s) to crop requests", m_args->m_polys)
+        .setErrorText("Invalid polygon specification. "
+                      "Must be valid GeoJSON/WKT");
+    args.add("header", "Header fields to forward with HTTP requests",
+             m_args->m_headers);
+    args.add("query", "Query parameters to forward with HTTP requests",
+             m_args->m_query);
+    args.add("ogr", "OGR filter geometries", m_args->m_ogr);
+}
+
+void CachedEptReader::setForwards(StringMap& headers, StringMap& query)
+{
+    try
+    {
+        if (!m_args->m_headers.is_null())
+            headers = m_args->m_headers.get<StringMap>();
+    }
+    catch (const std::exception& err)
+    {
+        throwError(std::string("Error parsing 'headers': ") + err.what());
+    }
+
+    try
+    {
+        if (!m_args->m_query.is_null())
+            query = m_args->m_query.get<StringMap>();
+    }
+    catch (const std::exception& err)
+    {
+        throwError(std::string("Error parsing 'query': ") + err.what());
+    }
+}
+
+void CachedEptReader::initialize()
+{
+    auto& debug(log()->get(LogLevel::Debug));
+
+    const std::size_t threads((std::max)(m_args->m_threads, size_t(4)));
+    if (threads > 100)
+        log()->get(LogLevel::Warning)
+            << "Using a large thread count: " << threads << " threads"
+            << std::endl;
+    m_p->pool.reset(new ThreadPool(threads));
+
+    StringMap headers;
+    StringMap query;
+    setForwards(headers, query);
+    m_p->connector.reset(new Connector(headers, query));
+
+    try
+    {
+        m_p->info.reset(new EptInfo(m_filename, *m_p->connector));
+        setSpatialReference(m_p->info->srs());
+        m_p->addons = Addon::load(*m_p->connector, m_args->m_addons);
+    }
+    catch (const arbiter::ArbiterError& err)
+    {
+        throwError(err.what());
+    }
+
+    if (!m_args->m_ogr.is_null())
+    {
+        auto& plist = m_args->m_polys;
+        std::vector<Polygon> ogrPolys = gdal::getPolygons(m_args->m_ogr);
+        plist.insert(plist.end(), ogrPolys.begin(), ogrPolys.end());
+    }
+
+    // Create transformations from our source data to the bounds SRS.
+    if (m_args->m_bounds.valid())
+    {
+        if (m_args->m_bounds.is2d())
+        {
+            m_p->bounds.box = BOX3D(m_args->m_bounds.to2d());
+            m_p->bounds.box.minz = (std::numeric_limits<double>::lowest)();
+            m_p->bounds.box.maxz = (std::numeric_limits<double>::max)();
+        }
+        else
+            m_p->bounds.box = m_args->m_bounds.to3d();
+        const SpatialReference& boundsSrs = m_args->m_bounds.spatialReference();
+        if (!m_p->info->srs().valid() && boundsSrs.valid())
+            throwError(
+                "Can't use bounds with SRS with data source that has no SRS.");
+        if (boundsSrs.valid())
+            m_p->bounds.xform = SrsTransform(m_p->info->srs(), boundsSrs);
+    }
+
+    // Create transform from the point source SRS to the poly SRS.
+    for (Polygon& poly : m_args->m_polys)
+    {
+        if (!poly.valid())
+            throwError("Geometrically invalid polygon in option 'polygon'.");
+
+        // Get the sub-polygons from a multi-polygon.
+        std::vector<Polygon> exploded = poly.polygons();
+        SrsTransform xform;
+        if (poly.srsValid())
+            xform.set(m_p->info->srs(), poly.getSpatialReference());
+        for (Polygon& p : exploded)
+        {
+            PolyXform ps{std::move(p), xform};
+            m_p->polys.push_back(ps);
+        }
+    }
+
+    try
+    {
+        handleOriginQuery();
+    }
+    catch (std::exception& e)
+    {
+        throwError(e.what());
+    }
+
+    // Figure out our max depth.
+    const double queryResolution(m_args->m_resolution);
+    // reseting depthEnd if initialize() has been called before
+    m_depthEnd = 0;
+    if (queryResolution)
+    {
+        double currentResolution =
+            (m_p->info->bounds().maxx - m_p->info->bounds().minx) /
+            m_p->info->span();
+
+        debug << "Root resolution: " << currentResolution << std::endl;
+
+        // To select the current resolution level, we need depthEnd to be one
+        // beyond it - this is a non-inclusive parameter.
+        ++m_depthEnd;
+
+        while (currentResolution > queryResolution)
+        {
+            currentResolution /= 2;
+            ++m_depthEnd;
+        }
+
+        debug << "Query resolution:  " << queryResolution << "\n";
+        debug << "Actual resolution: " << currentResolution << "\n";
+        debug << "Depth end: " << m_depthEnd << "\n";
+    }
+
+    debug << "Query bounds: " << m_p->bounds.box << "\n";
+    debug << "Threads: " << m_p->pool->size() << std::endl;
+}
+
+void CachedEptReader::handleOriginQuery()
+{
+    const std::string search(m_args->m_origin);
+
+    if (search.empty())
+        return;
+
+    log()->get(LogLevel::Debug)
+        << "Searching sources for " << search << std::endl;
+
+    std::string filename = m_p->info->sourcesDir() + "list.json";
+    NL::json sources;
+    try
+    {
+        String str(filename.data(), filename.size());
+        JsonCache::ConstAccessor ac;
+        if (jsonCache->find(ac, str))
+            sources = *ac;
+        else
+        {
+            sources = m_p->connector->getJson(filename);
+            jsonCache->insert(str, sources);
+        }
+    }
+    catch (const arbiter::ArbiterError& err)
+    {
+        throwError(err.what());
+    }
+    log()->get(LogLevel::Debug) << "Fetched sources list" << std::endl;
+
+    if (!sources.is_array())
+    {
+        throwError("Unexpected sources list: " + sources.dump());
+    }
+
+    if (search.find_first_not_of("0123456789") == std::string::npos)
+    {
+        // If the origin search is integral, then the OriginId value has been
+        // specified directly.
+        m_queryOriginId = std::stoll(search);
+    }
+    else
+    {
+        // Otherwise it's a file path (or part of one - for example selecting
+        // by a basename or a tile ID rather than a full path is convenient).
+        // Find it within the sources list, and make sure it's specified
+        // uniquely enough to select only one file.
+        for (size_t i = 0; i < sources.size(); ++i)
+        {
+            const NL::json& el = sources.at(i);
+            if (el["id"].get<std::string>().find(search) != std::string::npos)
+            {
+                if (m_queryOriginId != -1)
+                    throwError("Origin search ID is not unique.");
+                m_queryOriginId = static_cast<int64_t>(i);
+            }
+        }
+    }
+
+    if (m_queryOriginId == -1)
+    {
+        throwError("Failed lookup of origin: " + search);
+    }
+
+    if (m_queryOriginId >= (int64_t)sources.size())
+    {
+        throwError("Invalid origin ID");
+    }
+
+    // Now that we have our OriginId value, clamp the bounds to select only the
+    // data sources that overlap the selected origin.
+
+    const NL::json found(sources.at(m_queryOriginId));
+
+    try
+    {
+        BOX3D q(toBox3d(found["bounds"]));
+
+        if (m_p->bounds.box.valid())
+            m_p->bounds.box.clip(q);
+        else
+            m_p->bounds.box = q;
+
+        log()->get(LogLevel::Debug)
+            << "Query origin " << m_queryOriginId << ": "
+            << found["id"].get<std::string>() << std::endl;
+    }
+    catch (std::exception& e)
+    {
+        throwError(e.what());
+    }
+}
+
+QuickInfo CachedEptReader::inspect()
+{
+    QuickInfo qi;
+
+    initialize();
+
+    qi.m_bounds = m_p->info->boundsConforming();
+    qi.m_srs = m_p->info->srs();
+    qi.m_pointCount = m_p->info->points();
+
+    for (auto& el : m_p->info->dims())
+        qi.m_dimNames.push_back(el.first);
+
+    // If there is a spatial filter from an explicit --bounds, an origin query,
+    // or polygons, then we'll limit our number of points to be an upper bound,
+    // and clip our bounds to the selected region.
+    if (hasSpatialFilter())
+    {
+        log()->get(LogLevel::Debug)
+            << "Determining overlapping point count" << std::endl;
+
+        m_p->hierarchy.reset(new Hierarchy);
+        overlaps();
+
+        // If we've passed a spatial filter, determine an upper bound on the
+        // point count based on the hierarchy.
+        qi.m_pointCount = 0;
+        for (const Overlap& overlap : *m_p->hierarchy)
+            qi.m_pointCount += overlap.m_count;
+
+        // ABELL - This is wrong since we're not transforming the tile bounds to
+        // the
+        //  SRS of each clip region, but that seems like a lot of mess for
+        //  little value. Wait until someone complains. (Note that's it's a bit
+        //  different from queryOverlaps or we'd just call that.)
+        // Clip the resulting bounds to the intersection of:
+        //  - the query bounds (from an explicit bounds or an origin query)
+        //  - the extents of the polygon selection
+        BOX3D b;
+        b.grow(m_p->bounds.box);
+        for (const auto& poly : m_args->m_polys)
+            b.grow(poly.bounds());
+
+        if (b.valid())
+            qi.m_bounds.clip(b);
+    }
+    qi.m_valid = true;
+
+    return qi;
+}
+
+void CachedEptReader::addDimensions(PointLayoutPtr layout)
+{
+    for (auto& el : m_p->info->dims())
+    {
+        const std::string& name = el.first;
+        DimType& dt = el.second;
+
+        if (dt.m_xform.nonstandard())
+            layout->registerOrAssignDim(name, Dimension::Type::Double);
+        else
+            layout->registerOrAssignDim(name, dt.m_type);
+    }
+
+    for (Addon& addon : m_p->addons)
+        addon.setExternalId(
+            layout->registerOrAssignDim(addon.name(), addon.type()));
+}
+
+// Start a thread to read an overlap.  When the data has been read,
+// stick the tile on the queue and notify the main thread.
+void CachedEptReader::load(const Overlap& overlap)
+{
+    m_p->pool->add(
+        [this, overlap]()
+        {
+            // Read the tile.
+            CachedTileContents tile(overlap, *m_p->info, *m_p->connector,
+                                    m_p->addons);
+            tile.read();
+
+            // Put the tile on the output queue.
+            std::unique_lock<std::mutex> l(m_p->mutex);
+            m_p->contents.push(std::move(tile));
+            l.unlock();
+            m_p->contentsCv.notify_one();
+        });
+}
+
+void CachedEptReader::ready(PointTableRef table)
+{
+    // These may not exist, in general they are only needed to track point
+    // origins and ordering for an EPT writer.
+    m_nodeIdDim = table.layout()->findDim("EptNodeId");
+    m_pointIdDim = table.layout()->findDim("EptPointId");
+
+    m_p->hierarchy.reset(new Hierarchy);
+
+    // Determine all overlapping data files we'll need to fetch.
+    try
+    {
+        overlaps();
+    }
+    catch (std::exception& e)
+    {
+        throwError(e.what());
+    }
+
+    point_count_t overlapPoints(0);
+    for (const Overlap& overlap : *m_p->hierarchy)
+        overlapPoints += overlap.m_count;
+
+    if (overlapPoints > 1e8)
+    {
+        log()->get(LogLevel::Warning)
+            << overlapPoints << " will be downloaded" << std::endl;
+    }
+
+    m_pointId = 0;
+    m_tileCount = m_p->hierarchy->size();
+
+    // If we're running in standard mode, queue up all the requests for data.
+    // In streaming mode, queue up at most 4 to avoid having a ton of data
+    // show up at once. Others requests will be queued as the results
+    // are handled.
+    m_p->pool.reset(new ThreadPool(m_p->pool->numThreads()));
+    for (const Overlap& overlap : *m_p->hierarchy)
+        load(overlap);
+    if (table.supportsView())
+        m_artifactMgr = &table.artifactManager();
+}
+
+void CachedEptReader::overlaps()
+{
+    // Determine all the keys that overlap the queried area by traversing the
+    // EPT hierarchy:
+    //      https://entwine.io/entwine-point-tile.html#ept-hierarchy)
+    //
+    // Because this may require fetching lots of JSON files, it'll run in our
+    // thread pool.
+    Key key;
+    key.b = m_p->info->bounds();
+
+    {
+        m_nodeId = 1;
+        std::string filename =
+            m_p->info->hierarchyDir() + key.toString() + ".json";
+
+        // First, determine the overlapping nodes from the EPT resource.
+        NL::json sources;
+        String str(filename.data(), filename.size());
+        JsonCache::ConstAccessor ac;
+        if (jsonCache->find(ac, str))
+            sources = *ac;
+        else
+        {
+            sources = m_p->connector->getJson(filename);
+            jsonCache->insert(str, sources);
+        }
+
+        overlaps(*m_p->hierarchy, sources, key);
+    }
+    m_p->pool->await();
+
+    // Determine the addons that exist to correspond to tiles.
+    for (auto& addon : m_p->addons)
+    {
+        m_nodeId = 1;
+        std::string filename = addon.hierarchyDir() + key.toString() + ".json";
+
+        NL::json sources;
+        String str(filename.data(), filename.size());
+        JsonCache::ConstAccessor ac;
+        if (jsonCache->find(ac, str))
+            sources = *ac;
+        else
+        {
+            sources = m_p->connector->getJson(filename);
+            jsonCache->insert(str, sources);
+        }
+
+        overlaps(addon.hierarchy(), sources, key);
+        m_p->pool->await();
+    }
+}
+
+bool CachedEptReader::hasSpatialFilter() const
+{
+    return !m_p->polys.empty() || m_p->bounds.box.valid();
+}
+
+// Determine if an EPT tile overlaps our query boundary
+bool CachedEptReader::passesSpatialFilter(const BOX3D& tileBounds) const
+{
+    // Reproject the tile bounds to the largest rect. solid that contains all
+    // the corners.
+    auto reproject = [](BOX3D src, SrsTransform& xform) -> BOX3D
+    {
+        if (!xform.valid())
+            return src;
+
+        BOX3D b;
+        auto reprogrow = [&b, &xform](double x, double y, double z)
+        {
+            xform.transform(x, y, z);
+            b.grow(x, y, z);
+        };
+
+        reprogrow(src.minx, src.miny, src.minz);
+        reprogrow(src.maxx, src.miny, src.minz);
+        reprogrow(src.minx, src.maxy, src.minz);
+        reprogrow(src.maxx, src.maxy, src.minz);
+        reprogrow(src.minx, src.miny, src.maxz);
+        reprogrow(src.maxx, src.miny, src.maxz);
+        reprogrow(src.minx, src.maxy, src.maxz);
+        reprogrow(src.maxx, src.maxy, src.maxz);
+        return b;
+    };
+
+    auto boxOverlaps = [this, &reproject, &tileBounds]() -> bool
+    {
+        if (!m_p->bounds.box.valid())
+            return true;
+
+        // If the reprojected source bounds doesn't overlap our query bounds,
+        // we're done.
+        return reproject(tileBounds, m_p->bounds.xform)
+            .overlaps(m_p->bounds.box);
+    };
+
+    // Check the box of the key against our query polygon(s). If it doesn't
+    // overlap, we can skip
+    auto polysOverlap = [this, &reproject, &tileBounds]() -> bool
+    {
+        if (m_p->polys.empty())
+            return true;
+
+        for (auto& ps : m_p->polys)
+            if (!ps.poly.disjoint(reproject(tileBounds, ps.xform)))
+                return true;
+        return false;
+    };
+
+    // If there's no spatial filter, we always overlap.
+    if (!hasSpatialFilter())
+        return true;
+
+    // This lock is here because if a bunch of threads are using the transform
+    // at the same time, it seems to get corrupted. There may be other instances
+    // that need to be locked.
+    std::lock_guard<std::mutex> lock(m_p->mutex);
+    return boxOverlaps() && polysOverlap();
+}
+
+void CachedEptReader::overlaps(Hierarchy& target, const NL::json& hier,
+                               const Key& key)
+{
+    // If our key isn't in the hierarchy, we've totally traversed this tree
+    // branch (there are no lower nodes).
+    auto it = hier.find(key.toString());
+    if (it == hier.end())
+        return;
+
+    // If our query geometry doesn't overlap the tile or we're past the end of
+    // the requested depth, return.
+    if (!passesSpatialFilter(key.b) || (m_depthEnd && key.d >= m_depthEnd))
+        return;
+
+    int64_t numPoints(-2); // -2 will trigger an error below
+    try
+    {
+        numPoints = it->get<int64_t>();
+    }
+    catch (...)
+    {
+    }
+
+    if (numPoints == -1)
+    {
+        if (!m_hierarchyStep)
+            m_hierarchyStep = key.d;
+
+        // If the hierarchy points value here is -1, then we need to fetch the
+        // hierarchy subtree corresponding to this root.
+        m_p->pool->add(
+            [this, &target, key]()
+            {
+                try
+                {
+                    std::string filename =
+                        m_p->info->hierarchyDir() + key.toString() + ".json";
+
+                    NL::json sources;
+                    String str(filename.data(), filename.size());
+                    JsonCache::ConstAccessor ac;
+                    if (jsonCache->find(ac, str))
+                        sources = *ac;
+                    else
+                    {
+                        sources = m_p->connector->getJson(filename);
+                        jsonCache->insert(str, sources);
+                    }
+
+                    overlaps(target, sources, key);
+                }
+                catch (const arbiter::ArbiterError& err)
+                {
+                    throwError(err.what());
+                }
+            });
+    }
+    else if (numPoints < 0)
+    {
+        throwError("Invalid point count for key '" + key.toString() + "'.");
+    }
+    else
+    {
+        // Note that when processing addons, we set node IDs which may
+        // not match the base hierarchy, but it doesn't matter since
+        // they are never used.
+        {
+            std::lock_guard<std::mutex> lock(m_p->mutex);
+            target.emplace(key, (point_count_t)numPoints, m_nodeId++);
+        }
+
+        for (uint64_t dir(0); dir < 8; ++dir)
+            overlaps(target, hier, key.bisect(dir));
+    }
+}
+
+void CachedEptReader::checkTile(const CachedTileContents& tile)
+{
+    if (tile.error().size())
+    {
+        m_p->pool->stop();
+        throwError("Error reading tile: " + tile.error());
+    }
+}
+
+// This code runs in a single thread, so doesn't need locking.
+bool CachedEptReader::processPoint(PointRef& dst,
+                                   const CachedTileContents& tile)
+{
+    using namespace Dimension;
+
+    BasePointTable& t = tile.table();
+
+    // Save current point ID and increment so that we can return without
+    // worrying about m_pointId being correct on exit.
+    PointId pointId = m_pointId++;
+
+    PointRef p(t, pointId);
+    int64_t originId = p.getFieldAs<int64_t>(Id::OriginId);
+    if (m_queryOriginId != -1 && originId != m_queryOriginId)
+        return false;
+
+    auto passesBoundsFilter = [this](double x, double y, double z)
+    {
+        if (!m_p->bounds.box.valid())
+            return true;
+        m_p->bounds.xform.transform(x, y, z);
+        return m_p->bounds.box.contains(x, y, z);
+    };
+
+    auto passesPolyFilter = [this](double xo, double yo, double zo)
+    {
+        if (m_p->polys.empty())
+            return true;
+
+        for (PolyXform& ps : m_p->polys)
+        {
+            double x = xo;
+            double y = yo;
+            double z = zo;
+
+            ps.xform.transform(x, y, z);
+            if (ps.poly.contains(x, y))
+                return true;
+        }
+        return false;
+    };
+
+    double x = p.getFieldAs<double>(Id::X);
+    double y = p.getFieldAs<double>(Id::Y);
+    double z = p.getFieldAs<double>(Id::Z);
+
+    // If there is a spatial filter, make sure it passes.
+    if (hasSpatialFilter())
+        if (!passesBoundsFilter(x, y, z) || !passesPolyFilter(x, y, z))
+            return false;
+
+    for (auto& el : m_p->info->dims())
+    {
+        DimType& dt = el.second;
+        if (dt.m_id != Dimension::Id::X && dt.m_id != Dimension::Id::Y &&
+            dt.m_id != Dimension::Id::Z)
+        {
+            const double val =
+                p.getFieldAs<double>(dt.m_id) * dt.m_xform.m_scale.m_val +
+                dt.m_xform.m_offset.m_val;
+
+            dst.setField(dt.m_id, val);
+        }
+    }
+    dst.setField(Id::X, x);
+    dst.setField(Id::Y, y);
+    dst.setField(Id::Z, z);
+    dst.setField(m_nodeIdDim, tile.nodeId());
+    dst.setField(m_pointIdDim, pointId);
+    for (Addon& addon : m_p->addons)
+    {
+        Dimension::Id srcId = addon.localId();
+        BasePointTable* t = tile.addonTable(srcId);
+        if (t)
+        {
+            PointRef addonPoint(*t, pointId);
+            double val = addonPoint.getFieldAs<double>(srcId);
+            dst.setField(addon.externalId(), val);
+        }
+    }
+    return true;
+}
+
+point_count_t CachedEptReader::read(PointViewPtr view, point_count_t count)
+{
+#ifndef PDAL_HAVE_ZSTD
+    if (m_p->info->dataType() == EptInfo::DataType::Zstandard)
+        throwError("Cannot read Zstandard dataType: "
+                   "PDAL must be configured with WITH_ZSTD=On");
+#endif
+
+    point_count_t numRead = 0;
+
+    if (m_p->hierarchy->size())
+    {
+        // Pop tiles until there are no more, or wait for them to appear.
+        // Exit when we've handled all the tiles or we've read enough points.
+        do
+        {
+            std::unique_lock<std::mutex> l(m_p->mutex);
+            if (m_p->contents.size())
+            {
+                CachedTileContents tile = std::move(m_p->contents.front());
+                m_p->contents.pop();
+                l.unlock();
+                checkTile(tile);
+                process(view, tile, count - numRead);
+                numRead += tile.size();
+                m_tileCount--;
+            }
+            else
+                m_p->contentsCv.wait(l);
+        } while (m_tileCount && numRead <= count);
+    }
+
+    // Wait for any running threads to finish and don't start any others.
+    // Only relevant if we hit the count limit before reading all the tiles.
+    m_p->pool->stop();
+
+    // If we're using the addon writer, transfer the info and hierarchy
+    // to that stage.
+    if (m_nodeIdDim != Dimension::Id::Unknown)
+    {
+        EptArtifactPtr artifact(
+            new EptArtifact(std::move(m_p->info), std::move(m_p->hierarchy),
+                            std::move(m_p->connector), m_hierarchyStep));
+        m_artifactMgr->put("ept", artifact);
+    }
+
+    return numRead;
+}
+
+// Put the contents of a tile into the destination point view.
+void CachedEptReader::process(PointViewPtr dstView,
+                              const CachedTileContents& tile,
+                              point_count_t count)
+{
+    m_pointId = 0;
+    PointRef dstPoint(*dstView);
+    for (PointId idx = 0; idx < tile.size(); ++idx)
+    {
+        if (count-- == 0)
+            return;
+        dstPoint.setPointId(dstView->size());
+        processPoint(dstPoint, tile);
+    }
+}
+
+bool CachedEptReader::processOne(PointRef& point)
+{
+top:
+    if (m_tileCount == 0)
+        return false;
+
+    // If there is no active tile, grab one off the queue and ask for
+    // another if there are more.  If none are available, wait.
+    if (!m_p->currentTile)
+    {
+        do
+        {
+            std::unique_lock<std::mutex> l(m_p->mutex);
+            if (m_p->contents.size())
+            {
+                m_p->currentTile.reset(
+                    new CachedTileContents(std::move(m_p->contents.front())));
+                m_p->contents.pop();
+                break;
+            }
+            else
+                m_p->contentsCv.wait(l);
+        } while (true);
+        checkTile(*m_p->currentTile);
+    }
+
+    bool ok = processPoint(point, *m_p->currentTile);
+
+    // If we've processed all the points in the current tile, pop it.
+    // If we've processed all the tiles, return false to indicate that
+    // we're done.
+    if (m_pointId == m_p->currentTile->size())
+    {
+        m_pointId = 0;
+        m_p->currentTile.reset();
+        --m_tileCount;
+    }
+
+    // If we didn't pass a point, try again.
+    if (!ok)
+        goto top;
+
+    return true;
+}
+
+} // namespace pdal

--- a/cachedept/io/CachedEptReader.hpp
+++ b/cachedept/io/CachedEptReader.hpp
@@ -1,0 +1,116 @@
+/******************************************************************************
+* Copyright (c) 2018, Connor Manning (connor@hobu.co)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or key materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <memory>
+#include <unordered_set>
+
+#include <pdal/JsonFwd.hpp>
+#include <pdal/Reader.hpp>
+#include <pdal/Streamable.hpp>
+#include <pdal/util/Bounds.hpp>
+
+namespace pdal
+{
+
+class CachedConnector;
+class EptInfo;
+class Key;
+class CachedTileContents;
+struct Overlap;
+using Hierarchy = std::unordered_set<Overlap>;
+using StringMap = std::map<std::string, std::string>;
+
+class PDAL_DLL CachedEptReader : public Reader, public Streamable
+{
+    FRIEND_TEST(EptReaderTest, getRemoteType);
+    FRIEND_TEST(EptReaderTest, getCoercedType);
+
+public:
+    CachedEptReader();
+    virtual ~CachedEptReader();
+    std::string getName() const override;
+
+private:
+    virtual void addArgs(ProgramArgs& args) override;
+    virtual void initialize() override;
+    virtual QuickInfo inspect() override;
+    virtual void addDimensions(PointLayoutPtr layout) override;
+    virtual void ready(PointTableRef table) override;
+    virtual point_count_t read(PointViewPtr view, point_count_t count) override;
+    virtual bool processOne(PointRef& point) override;
+
+    // If argument "origin" is specified, this function will clip the query
+    // bounds to the bounds of the specified origin and set m_queryOriginId to
+    // the selected OriginId value.  If the selected origin is not found, throw.
+    void handleOriginQuery();
+    void setForwards(StringMap& headers, StringMap& query);
+
+    // Aggregate all EPT keys overlapping our query bounds and their number of
+    // points from a walk through the hierarchy.  Each of these keys will be
+    // downloaded during the 'read' section.
+    void overlaps();
+    void overlaps(Hierarchy& target, const NL::json& current, const Key& key);
+    bool hasSpatialFilter() const;
+    bool passesSpatialFilter(const BOX3D& tileBounds) const;
+    void process(PointViewPtr dstView, const CachedTileContents& tile,
+                 point_count_t count);
+    bool processPoint(PointRef& dst, const CachedTileContents& tile);
+    void load(const Overlap& overlap);
+    void checkTile(const CachedTileContents& tile);
+
+    struct Args;
+    std::unique_ptr<Args> m_args;
+    struct Private;
+    std::unique_ptr<Private> m_p;
+
+    uint64_t m_tileCount;
+    int64_t m_queryOriginId = -1;
+
+    uint64_t m_depthEnd = 0;    // Zero indicates selection of all depths.
+    uint64_t m_hierarchyStep = 0;
+
+    Dimension::Id m_nodeIdDim = Dimension::Id::Unknown;
+    Dimension::Id m_pointIdDim = Dimension::Id::Unknown;
+
+    ArtifactManager *m_artifactMgr;
+    PointId m_pointId = 0;
+    uint64_t m_nodeId;
+};
+
+} // namespace pdal
+

--- a/cachedept/io/CachedTileContents.cpp
+++ b/cachedept/io/CachedTileContents.cpp
@@ -1,0 +1,220 @@
+/******************************************************************************
+ * Copyright (c) 2020, Hobu Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include <io/LasReader.hpp>
+#include <pdal/compression/ZstdCompression.hpp>
+
+#include "private/ept/Connector.hpp"
+#include "private/ept/EptInfo.hpp"
+#include "CachedTileContents.hpp"
+#include "private/ept/VectorPointTable.hpp"
+#include "private/thread-safe-lru/string-key.h"
+#include "private/thread-safe-lru/scalable-cache.h"
+
+namespace pdal
+{
+
+    
+typedef tstarling::ThreadSafeStringKey String;
+typedef String::HashCompare HashCompare;
+typedef tstarling::ThreadSafeLRUCache<String, BasePointTablePtr, HashCompare>
+    TableCache;
+
+std::unique_ptr<TableCache> tableCache =
+    std::unique_ptr<TableCache> (new TableCache(4194304));
+
+void CachedTileContents::read()
+{
+    try
+    {
+        if (m_info.dataType() == EptInfo::DataType::Laszip)
+            readLaszip();
+        else if (m_info.dataType() == EptInfo::DataType::Binary)
+            readBinary();
+#ifdef PDAL_HAVE_ZSTD
+        else if (m_info.dataType() == EptInfo::DataType::Zstandard)
+            readZstandard();
+#endif
+        else
+            throw pdal_error("Unrecognized EPT dataType");
+//ABELL - Should check that we read the number of points specified in the
+//  overlap.
+        // Read addon information after the native data, we'll possibly
+        // overwrite attributes.
+        for (const Addon& addon : m_addons)
+            readAddon(addon);
+    }
+    catch (const std::exception& ex)
+    {
+        m_error = ex.what();
+    }
+    catch (...)
+    {
+        m_error = "Unknown exception when reading tile contents";
+    }
+}
+
+void CachedTileContents::readLaszip()
+{
+    // If the file is remote (HTTP, S3, Dropbox, etc.), getLocalHandle will
+    // download the file and `localPath` will return the location of the
+    // downloaded file in a temporary directory.  Otherwise it's a no-op.
+    std::string filename = m_info.dataDir() + key().toString() + ".laz";
+    String key(filename.data(), filename.size());
+    TableCache::ConstAccessor ac;
+    if (tableCache->find(ac, key))
+        m_table = *ac;
+    else
+    {
+        auto handle = m_connector.getLocalHandle(filename);
+
+        m_table.reset(new ColumnPointTable);
+
+        Options options;
+        options.add("filename", handle.localPath());
+        options.add("use_eb_vlr", true);
+        options.add("nosrs", true);
+
+        LasReader reader;
+        reader.setOptions(options);
+
+        reader.prepare(*m_table);
+        reader.execute(*m_table);
+
+        tableCache->insert(key, m_table);
+    }
+}
+
+void CachedTileContents::readBinary()
+{
+    std::string filename = m_info.dataDir() + key().toString() + ".bin";
+    String key(filename.data(), filename.size());
+    TableCache::ConstAccessor ac;
+    if (tableCache->find(ac, key))
+        m_table = *ac;
+    else
+    {
+        auto data(m_connector.getBinary(filename));
+
+        VectorPointTable *vpt = new VectorPointTable(m_info.remoteLayout());
+        vpt->buffer() = std::move(data);
+        m_table.reset(vpt);
+
+        transform();
+
+        tableCache->insert(key, m_table);
+    }
+}
+
+#ifdef PDAL_HAVE_ZSTD
+void CachedTileContents::readZstandard()
+{
+    std::string filename = m_info.dataDir() + key().toString() + ".zst";
+    TableCache::ConstAccessor ac;
+    String key(filename.data(), filename.size());
+    if (tableCache->find(ac, key))
+        m_table = *ac;
+    else
+    {
+        auto compressed(m_connector.getBinary(filename));
+        std::vector<char> data;
+        pdal::ZstdDecompressor dec([&data](char* pos, std::size_t size)
+        {
+            data.insert(data.end(), pos, pos + size);
+        });
+
+        dec.decompress(compressed.data(), compressed.size());
+
+        VectorPointTable *vpt = new VectorPointTable(m_info.remoteLayout());
+        vpt->buffer() = std::move(data);
+        m_table.reset(vpt);
+
+        transform();
+        tableCache->insert(key, m_table);
+    }
+}
+#else
+void CachedTileContents::readZstandard()
+{}
+#endif // PDAL_HAVE_ZSTD
+
+void CachedTileContents::readAddon(const Addon& addon)
+{
+    m_addonTables[addon.localId()] = nullptr;
+
+    point_count_t addonPoints = addon.points(key());
+    if (addonPoints == 0)
+        return;
+
+    // If the addon hierarchy exists, it must match the EPT data.
+    if (addonPoints != size())
+        throw pdal_error("Invalid addon hierarchy");
+
+    std::string filename = addon.dataDir() + key().toString() + ".bin";
+    const auto data(m_connector.getBinary(filename));
+
+    if (size() * Dimension::size(addon.type()) != data.size())
+        throw pdal_error("Invalid addon content length");
+
+    VectorPointTable *vpt = new VectorPointTable(addon.layout());
+    vpt->buffer() = std::move(data);
+    m_addonTables[addon.localId()] = BasePointTablePtr(vpt);
+}
+
+void CachedTileContents::transform()
+{
+    using D = Dimension::Id;
+
+    // Shorten long name.
+    const XForm& xf = m_info.dimType(Dimension::Id::X).m_xform;
+    const XForm& yf = m_info.dimType(Dimension::Id::Y).m_xform;
+    const XForm& zf = m_info.dimType(Dimension::Id::Z).m_xform;
+
+    PointRef p(*m_table);
+    for (PointId i = 0; i < size(); ++i)
+    {
+        p.setPointId(i);
+
+        // Scale the XYZ values.
+        p.setField(D::X, p.getFieldAs<double>(D::X) * xf.m_scale.m_val +
+            xf.m_offset.m_val);
+        p.setField(D::Y, p.getFieldAs<double>(D::Y) * yf.m_scale.m_val +
+            yf.m_offset.m_val);
+        p.setField(D::Z, p.getFieldAs<double>(D::Z) * zf.m_scale.m_val +
+            zf.m_offset.m_val);
+    }
+}
+
+} // namespace pdal
+

--- a/cachedept/io/CachedTileContents.hpp
+++ b/cachedept/io/CachedTileContents.hpp
@@ -1,0 +1,98 @@
+/******************************************************************************
+ * Copyright (c) 2020, Hobu Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <pdal/PointView.hpp>
+#include <pdal/pdal_types.hpp>
+
+#include "private/ept/Addon.hpp"
+#include "private/ept/Overlap.hpp"
+#include "private/ept/Connector.hpp"
+
+namespace pdal
+{
+
+class EptInfo;
+class Connector;
+class BasePointTable;
+using BasePointTablePtr = std::shared_ptr<BasePointTable>;
+
+class CachedTileContents
+{
+public:
+    CachedTileContents(const Overlap& overlap, const EptInfo& info,
+            const Connector& connector, const AddonList& addons) :
+        m_overlap(overlap), m_info(info), m_connector(connector),
+        m_addons(addons)
+    {}
+
+    BasePointTable& table() const
+        { return *m_table; }
+    const Key& key() const
+        { return m_overlap.m_key; }
+    point_count_t nodeId() const
+        { return m_overlap.m_nodeId; }
+    //ABELL - This is bad. We're assuming that the actual number of points we have matches
+    // what our index information told us. This may not be the case because of some
+    // issue. Downstream handling may depend on this being the actual number of points
+    // in the tile, rather than the number that were *supposed to be* in the tile.
+    point_count_t size() const
+        { return m_overlap.m_count; }
+    const std::string& error() const
+        { return m_error; }
+    BasePointTable *addonTable(Dimension::Id id) const
+        { return const_cast<CachedTileContents *>(this)->m_addonTables[id].get(); }
+    void read();
+
+private:
+    Overlap m_overlap;
+    const EptInfo& m_info;
+    const Connector& m_connector;
+    const AddonList& m_addons;
+    std::string m_error;
+    // Table for the base point data.
+    BasePointTablePtr m_table;
+    // Tables for the add on data.
+    std::map<Dimension::Id, BasePointTablePtr> m_addonTables;
+
+    void readLaszip();
+    void readBinary();
+    void readZstandard();
+    void readAddon(const Addon& addon);
+    void transform();
+};
+
+} // namespace pdal
+

--- a/cachedept/io/private/ept/Addon.cpp
+++ b/cachedept/io/private/ept/Addon.cpp
@@ -1,0 +1,141 @@
+/******************************************************************************
+ * Copyright (c) 2020, Hobu Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include <nlohmann/json.hpp>
+
+#include <pdal/util/FileUtils.hpp>
+
+#include "Addon.hpp"
+#include "Connector.hpp"
+
+namespace pdal
+{
+
+point_count_t Addon::points(const Key& key) const
+{
+    auto it = m_hierarchy.find(key);
+    return (it == m_hierarchy.end() ? 0 : it->m_count);
+}
+
+std::string Addon::dataDir() const
+{
+    return FileUtils::getDirectory(m_filename) + "ept-data/";
+}
+
+std::string Addon::hierarchyDir() const
+{
+    return FileUtils::getDirectory(m_filename) + "ept-hierarchy/";
+}
+
+AddonList Addon::store(const Connector& connector, const NL::json& spec,
+                       const PointLayout& layout)
+{
+    AddonList addons;
+    std::string filename;
+    try
+    {
+        for (auto it : spec.items())
+        {
+            std::string filename = it.key();
+            std::string dimName = it.value().get<std::string>();
+            if (!Utils::endsWith(filename, "ept-addon.json"))
+                filename += "/ept-addon.json";
+
+            Dimension::Id id = layout.findDim(dimName);
+            if (id == Dimension::Id::Unknown)
+                throw pdal_error(
+                    "Invalid dimension '" + dimName +
+                    "' in "
+                    "addon specification. Does not exist in source data.");
+            Dimension::Type type = layout.dimType(id);
+            std::string typestring = Dimension::toName(Dimension::base(type));
+            size_t size = Dimension::size(type);
+
+            Addon addon(dimName, filename, type);
+
+            NL::json meta;
+            meta["type"] = typestring;
+            meta["size"] = size;
+            meta["version"] = "1.0.0";
+            meta["dataType"] = "binary";
+
+            connector.makeDir(FileUtils::getDirectory(filename));
+            connector.put(filename, meta.dump());
+
+            addons.emplace_back(dimName, filename, type);
+            addons.back().setExternalId(id);
+        }
+    }
+    catch (NL::json::parse_error&)
+    {
+        throw pdal_error("Unable to parse EPT addon file '" + filename + "'.");
+    }
+    return addons;
+}
+
+AddonList Addon::load(const Connector& connector, const NL::json& spec)
+{
+    AddonList addons;
+    std::string filename;
+    try
+    {
+        for (auto it : spec.items())
+        {
+            std::string dimName = it.key();
+            std::string filename = it.value().get<std::string>();
+            if (!Utils::endsWith(filename, "ept-addon.json"))
+                filename += "/ept-addon.json";
+
+            addons.push_back(loadAddon(connector, dimName, filename));
+        }
+    }
+    catch (NL::json::parse_error&)
+    {
+        throw pdal_error("Unable to parse EPT addon file '" + filename + "'.");
+    }
+    return addons;
+}
+
+Addon Addon::loadAddon(const Connector& connector, const std::string& dimName,
+                       const std::string& filename)
+{
+    NL::json info = connector.getJson(filename);
+    std::string typestring = info["type"].get<std::string>();
+    uint64_t size = info["size"].get<uint64_t>();
+    Dimension::Type type = Dimension::type(typestring, size);
+
+    return Addon(dimName, filename, type);
+}
+
+} // namespace pdal

--- a/cachedept/io/private/ept/Addon.hpp
+++ b/cachedept/io/private/ept/Addon.hpp
@@ -1,0 +1,100 @@
+/******************************************************************************
+ * Copyright (c) 2018, Connor Manning
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <list>
+#include <string>
+
+#include <pdal/JsonFwd.hpp>
+#include <pdal/PointLayout.hpp>
+
+#include "Overlap.hpp"
+
+namespace pdal
+{
+
+class Addon;
+class Connector;
+using AddonList = std::vector<Addon>;
+
+class Addon
+{
+public:
+    Addon(const std::string& dimName, const std::string& filename,
+            Dimension::Type type) :
+        m_name(dimName), m_filename(filename), m_type(type)
+    { m_localId = m_layout.registerOrAssignDim(dimName, type); }
+
+    std::string name() const
+        { return m_name; }
+    std::string filename() const
+        { return m_filename; }
+    Dimension::Type type() const
+        { return m_type; }
+    // Id for the local (internal) layout
+    Dimension::Id localId() const
+        { return m_localId; }
+    // Id for the layout to which we'll copy data (ultimate PDAL ID).
+    Dimension::Id externalId() const
+        { return m_externalId; }
+    void setExternalId(Dimension::Id externalId)
+        { m_externalId = externalId; }
+    Hierarchy& hierarchy()
+        { return m_hierarchy; }
+    PointLayout& layout() const
+        { return const_cast<PointLayout &>(m_layout); }
+    point_count_t points(const Key& key) const;
+    std::string dataDir() const;
+    std::string hierarchyDir() const;
+    static AddonList store(const Connector& connector, const NL::json& spec,
+        const PointLayout& layout);        
+    static AddonList load(const Connector& connector, const NL::json& spec);
+
+private:
+    std::string m_name;
+    std::string m_filename;
+    Dimension::Type m_type;
+    Dimension::Id m_localId;
+    Dimension::Id m_externalId;
+
+    Hierarchy m_hierarchy;
+    PointLayout m_layout;
+
+    static Addon loadAddon(const Connector& connector,
+        const std::string& dimName, const std::string& filename);
+};
+
+} // namespace pdal
+

--- a/cachedept/io/private/ept/Connector.cpp
+++ b/cachedept/io/private/ept/Connector.cpp
@@ -1,0 +1,109 @@
+/******************************************************************************
+ * Copyright (c) 2018, Connor Manning
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include "Connector.hpp"
+
+#include <pdal/pdal_types.hpp>
+
+namespace pdal
+{
+
+Connector::Connector() : m_arbiter(new arbiter::Arbiter())
+{}
+
+Connector::Connector(const StringMap& headers, const StringMap& query) :
+    m_arbiter(new arbiter::Arbiter), m_headers(headers), m_query(query)
+{}    
+
+std::string Connector::get(const std::string& path) const
+{
+    if (m_arbiter->isLocal(path))
+        return m_arbiter->get(path);
+    else
+        return m_arbiter->get(path, m_headers, m_query);
+}
+
+NL::json Connector::getJson(const std::string& path) const
+{
+    try
+    {
+        return NL::json::parse(get(path));
+    }
+    catch (NL::json::parse_error& err)
+    {
+        throw pdal_error("File '" + path + "' contained invalid JSON: " +
+            err.what());
+    }
+}
+
+std::vector<char> Connector::getBinary(const std::string& path) const
+{
+    if (m_arbiter->isLocal(path))
+        return m_arbiter->getBinary(path);
+    else
+        return m_arbiter->getBinary(path, m_headers, m_query);
+}
+
+
+arbiter::LocalHandle Connector::getLocalHandle(const std::string& path) const
+{
+    if (m_arbiter->isLocal(path))
+        return m_arbiter->getLocalHandle(path);
+    else
+        return m_arbiter->getLocalHandle(path, m_headers, m_query);
+}
+
+void Connector::put(const std::string& path, const std::vector<char>& buf) const
+{
+    if (m_arbiter->isLocal(path))
+        return m_arbiter->put(path, buf);
+    else
+        return m_arbiter->put(path, buf, m_headers, m_query);
+}
+
+void Connector::put(const std::string& path, const std::string& data) const
+{
+    if (m_arbiter->isLocal(path))
+        return m_arbiter->put(path, data);
+    else
+        return m_arbiter->put(path, data, m_headers, m_query);
+}
+
+void Connector::makeDir(const std::string& path) const
+{
+    if (m_arbiter->isLocal(path))
+        arbiter::mkdirp(path);
+}
+
+} // namespace pdal

--- a/cachedept/io/private/ept/Connector.hpp
+++ b/cachedept/io/private/ept/Connector.hpp
@@ -1,0 +1,64 @@
+/******************************************************************************
+ * Copyright (c) 2018, Connor Manning
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <arbiter/arbiter.hpp>
+
+namespace pdal
+{
+
+using StringMap = std::map<std::string, std::string>;
+
+class Connector
+{
+    std::unique_ptr<arbiter::Arbiter> m_arbiter;
+    StringMap m_headers;
+    StringMap m_query;
+
+public:
+    Connector();
+    Connector(const StringMap& headers, const StringMap& query);
+
+    std::string get(const std::string& path) const;
+    NL::json getJson(const std::string& path) const;
+    std::vector<char> getBinary(const std::string& path) const;
+    arbiter::LocalHandle getLocalHandle(const std::string& path) const;
+    void put(const std::string& path, const std::vector<char>& data) const;
+    void put(const std::string& path, const std::string& data) const;
+    void makeDir(const std::string& path) const;
+};
+
+} // namespace pdal
+

--- a/cachedept/io/private/ept/EptArtifact.hpp
+++ b/cachedept/io/private/ept/EptArtifact.hpp
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * Copyright (c) 2018, Connor Manning
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <memory>
+
+#include <pdal/Artifact.hpp>
+#include "Connector.hpp"
+#include "EptInfo.hpp"
+#include "Overlap.hpp"
+
+namespace pdal
+{
+
+class EptArtifact : public Artifact
+{
+public:
+    EptArtifact(std::unique_ptr<EptInfo> info,
+            std::unique_ptr<Hierarchy> hierarchy,
+            std::unique_ptr<Connector> connector, size_t hierarchyStep) :
+        m_info(std::move(info)), m_hierarchy(std::move(hierarchy)),
+        m_connector(std::move(connector)), m_hierarchyStep(hierarchyStep)
+    {}
+
+    std::unique_ptr<EptInfo> m_info;
+    std::unique_ptr<Hierarchy> m_hierarchy;
+    std::unique_ptr<Connector> m_connector;
+    size_t m_hierarchyStep;
+};
+using EptArtifactPtr = std::shared_ptr<EptArtifact>;
+
+} // namespace pdal
+

--- a/cachedept/io/private/ept/EptInfo.cpp
+++ b/cachedept/io/private/ept/EptInfo.cpp
@@ -1,0 +1,186 @@
+/******************************************************************************
+ * Copyright (c) 2018, Connor Manning
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include "Connector.hpp"
+#include "EptInfo.hpp"
+#include "EptSupport.hpp"
+
+#include <pdal/util/FileUtils.hpp>
+#include <pdal/util/Utils.hpp>
+
+namespace pdal
+{
+
+EptInfo::EptInfo(const std::string& info)
+{
+    try
+    {
+        m_info = NL::json::parse(info);
+    }
+    catch(NL::json::parse_error&)
+    {
+        throw pdal_error("Unable to parse EPT info as JSON.");
+    }
+    initialize();
+}
+
+EptInfo::EptInfo(const std::string& filename, const Connector& connector) :
+    m_filename(filename)
+{
+    if (Utils::startsWith(m_filename, "ept://"))
+    {
+        m_filename = m_filename.substr(6);
+        if (!Utils::endsWith(m_filename, "/ept.json"))
+            m_filename += "/ept.json";
+    }
+    m_info = connector.getJson(m_filename);
+    initialize();
+}
+
+void EptInfo::initialize()
+{
+    m_bounds = toBox3d(m_info.at("bounds"));
+    m_boundsConforming = toBox3d(m_info.at("boundsConforming"));
+    m_points = m_info.value<uint64_t>("points", 0);
+    m_span = m_info.at("span").get<uint64_t>();
+
+    auto iSrs = m_info.find("srs");
+    if (iSrs != m_info.end() && iSrs->size())
+    {
+        std::string wkt;
+        auto iWkt = iSrs->find("wkt");
+        auto iAuthority = iSrs->find("authority");
+        auto iHorizontal = iSrs->find("horizontal");
+        auto iVertical = iSrs->find("vertical");
+
+        if (iWkt != iSrs->end())
+        {
+            if (!iWkt->is_string())
+                throw pdal_error("srs.wkt must be specified as a string. "
+                        "Found '" + iWkt->dump() + "'.");
+            wkt = iWkt->get<std::string>();
+        }
+        else
+        {
+            if (iAuthority == iSrs->end() || iHorizontal == iSrs->end())
+                throw pdal_error("srs must be defined with at least one of "
+                        "wkt or both authority and horizontal specifications.");
+            if (!iAuthority->is_string())
+                throw pdal_error("srs.authority must be specified as a "
+                        "string.  Found '" + iAuthority->dump() + "'.");
+            wkt = iAuthority->get<std::string>();
+
+            std::string horiz;
+            if (iHorizontal->is_number_unsigned())
+                horiz = std::to_string(iHorizontal->get<uint64_t>());
+            else if (iHorizontal->is_string())
+                horiz = iHorizontal->get<std::string>();
+            else
+                throw pdal_error("srs.horizontal must be specified as a "
+                    "non-negative integer or equivalent string. "
+                    "Found '" + iHorizontal->dump() + "'.");
+            wkt += ":" + horiz;
+
+            if (iVertical != iSrs->end())
+            {
+                std::string vert;
+                if (iVertical->is_number_unsigned())
+                    vert = std::to_string(iVertical->get<uint64_t>());
+                else if (iVertical->is_string())
+                    vert = iVertical->get<std::string>();
+                else
+                    throw pdal_error("srs.vertical must be specified as a "
+                            "non-negative integer or equivalent string. "
+                            "Found '" + iVertical->dump() + "'.");
+                wkt += "+" + vert;
+            }
+        }
+        m_srs.set(wkt);
+        if (!m_srs.valid())
+            throw pdal_error("Invalid/unknown srs.wkt specification.");
+    }
+
+    const std::string dt = m_info.at("dataType").get<std::string>();
+    if (dt == "laszip")
+        m_dataType = DataType::Laszip;
+    else if (dt == "binary")
+        m_dataType = DataType::Binary;
+    else if (dt == "zstandard")
+        m_dataType = DataType::Zstandard;
+    else
+        throw pdal_error("Unrecognized EPT dataType: " + dt);
+
+    NL::json& schema = m_info["schema"];
+    for (NL::json element: schema)
+    {
+        std::string name = element["name"].get<std::string>();
+        std::string typestring = element["type"].get<std::string>();
+        uint64_t size = element["size"].get<uint64_t>();
+        Dimension::Type type = Dimension::type(typestring, size);
+        double scale = element.value("scale", 1.0);
+        double offset = element.value("offset", 0);
+
+        name = Dimension::fixName(name);
+        Dimension::Id id = m_remoteLayout.registerOrAssignFixedDim(name, type);
+        m_dims[name] = DimType(id, type, scale, offset);
+    }
+    m_remoteLayout.finalize();
+}
+
+DimType EptInfo::dimType(Dimension::Id id) const
+{
+    //ABELL - This is yuck.  The map of strings to DimType is bad.
+    for (auto it = m_dims.begin(); it != m_dims.end(); ++it)
+        if (it->second.m_id == id)
+            return it->second;
+    return DimType();
+}
+
+std::string EptInfo::dataDir() const
+{
+    return FileUtils::getDirectory(m_filename) + "ept-data/";
+}
+
+std::string EptInfo::hierarchyDir() const
+{
+    return FileUtils::getDirectory(m_filename) + "ept-hierarchy/";
+}
+
+std::string EptInfo::sourcesDir() const
+{
+    return FileUtils::getDirectory(m_filename) + "ept-sources/";
+}
+
+} // namespace pdal
+

--- a/cachedept/io/private/ept/EptInfo.hpp
+++ b/cachedept/io/private/ept/EptInfo.hpp
@@ -1,0 +1,99 @@
+/******************************************************************************
+ * Copyright (c) 2018, Connor Manning
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <pdal/DimType.hpp>
+#include <pdal/SpatialReference.hpp>
+#include <pdal/util/Bounds.hpp>
+
+#include "FixedPointLayout.hpp"
+
+namespace pdal
+{
+
+class Connector;
+
+class EptInfo
+{
+public:
+    enum class DataType
+    {
+        Laszip,
+        Binary,
+        Zstandard
+    };
+
+    EptInfo(const std::string& info);
+    EptInfo(const std::string& filename, const Connector& connector);
+
+    const BOX3D& bounds() const { return m_bounds; }
+    const BOX3D& boundsConforming() const { return m_boundsConforming; }
+    uint64_t points() const { return m_points; }
+    uint64_t span() const { return m_span; }
+    DataType dataType() const { return m_dataType; }
+    const SpatialReference& srs() const { return m_srs; }
+    const NL::json& json() { return m_info; }
+    std::map<std::string, DimType>& dims() { return m_dims; }
+    DimType dimType(Dimension::Id id) const;
+    PointLayout& remoteLayout() const { return m_remoteLayout; }
+    std::string dataDir() const;
+    std::string hierarchyDir() const;
+    std::string sourcesDir() const;
+
+private:
+    // Info comes from the values here:
+    // https://entwine.io/entwine-point-tile.html#ept-json
+    NL::json m_info;
+    BOX3D m_bounds;
+    BOX3D m_boundsConforming;
+    uint64_t m_points = 0;
+    std::map<std::string, DimType> m_dims;
+
+    // The span is the length, width, and depth of the octree grid.  For
+    // example, a dataset oriented as a 256*256*256 octree grid would have a
+    // span of 256.
+    //
+    // See: https://entwine.io/entwine-point-tile.html#span
+    uint64_t m_span = 0;
+    DataType m_dataType;
+    SpatialReference m_srs;
+    std::string m_filename;
+    mutable FixedPointLayout m_remoteLayout;
+
+    void initialize();
+};
+
+} // namespace pdal
+

--- a/cachedept/io/private/ept/EptSupport.hpp
+++ b/cachedept/io/private/ept/EptSupport.hpp
@@ -1,0 +1,55 @@
+/******************************************************************************
+ * Copyright (c) 2018, Connor Manning
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <pdal/util/Bounds.hpp>
+
+namespace pdal
+{
+
+inline BOX3D toBox3d(const NL::json& b)
+{
+    if (!b.is_array() || b.size() != 6)
+    {
+        throw pdal_error("Invalid bounds specification: " + b.dump());
+    }
+
+    return BOX3D(b[0].get<double>(), b[1].get<double>(), b[2].get<double>(),
+            b[3].get<double>(), b[4].get<double>(), b[5].get<double>());
+}
+
+} // namespace pdal
+

--- a/cachedept/io/private/ept/FixedPointLayout.cpp
+++ b/cachedept/io/private/ept/FixedPointLayout.cpp
@@ -1,0 +1,83 @@
+/******************************************************************************
+ * Copyright (c) 2020, Hobu Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include <pdal/util/Algorithm.hpp>
+
+#include "FixedPointLayout.hpp"
+
+namespace pdal
+{
+
+bool FixedPointLayout::update(Dimension::Detail dimDetail,
+    const std::string& name)
+{
+    if (m_finalized)
+        return m_propIds.count(name);
+
+    if (!Utils::contains(m_used, dimDetail.id()))
+    {
+        dimDetail.setOffset(m_pointSize);
+
+        m_pointSize += dimDetail.size();
+        m_used.push_back(dimDetail.id());
+        m_detail[Utils::toNative(dimDetail.id())] = dimDetail;
+
+        return true;
+    }
+
+    return false;
+}
+
+void FixedPointLayout::registerFixedDim(const Dimension::Id id,
+    const Dimension::Type type)
+{
+    Dimension::Detail dd = m_detail[Utils::toNative(id)];
+    dd.setType(type);
+    update(dd, Dimension::name(id));
+}
+
+Dimension::Id FixedPointLayout::registerOrAssignFixedDim(const std::string name,
+    const Dimension::Type type)
+{
+    Dimension::Id id = Dimension::id(name);
+    if (id != Dimension::Id::Unknown)
+    {
+        registerFixedDim(id, type);
+        return id;
+    }
+    return assignDim(name, type);
+}
+
+} // namespace pdal
+

--- a/cachedept/io/private/ept/FixedPointLayout.hpp
+++ b/cachedept/io/private/ept/FixedPointLayout.hpp
@@ -1,0 +1,62 @@
+/******************************************************************************
+ * Copyright (c) 2018, Connor Manning
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <pdal/PointTable.hpp>
+
+namespace pdal
+{
+
+class FixedPointLayout : public PointLayout
+{
+    // The default PointLayout class may reorder dimension entries for packing
+    // efficiency.  However if a PointLayout is intended to be mapped to data
+    // coming from a remote source, then the dimensions must retain their order.
+    // FixedPointLayout retains the order of dimensions as they are registered,
+    // as well as adding a custom assignment function that makes sure XYZ are
+    // registered as their appropriate remote type rather than always as
+    // doubles.
+public:
+    void registerFixedDim(Dimension::Id id, Dimension::Type type);
+    Dimension::Id registerOrAssignFixedDim(std::string name,
+        Dimension::Type type);
+
+protected:
+    PDAL_DLL virtual bool update(pdal::Dimension::Detail dimDetail,
+        const std::string& name) override;
+};
+
+} // namespace pdal
+

--- a/cachedept/io/private/ept/Key.hpp
+++ b/cachedept/io/private/ept/Key.hpp
@@ -1,0 +1,165 @@
+/******************************************************************************
+ * Copyright (c) 2018, Connor Manning
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <functional>  // for hash
+
+namespace pdal
+{
+
+class PDAL_DLL Key
+{
+    // An EPT key representation (see https://git.io/fAiBh).  A depth/X/Y/Z key
+    // representing a data node, as well as the bounds of the contained data.
+public:
+    Key()
+    {}
+
+    Key(const std::string& s)
+    {
+        const StringList tokens(Utils::split(s, '-'));
+        if (tokens.size() != 4)
+            throw pdal_error("Invalid EPT KEY: " + s);
+        d = std::stoi(tokens[0]);
+        x = std::stoi(tokens[1]);
+        y = std::stoi(tokens[2]);
+        z = std::stoi(tokens[3]);
+    }
+
+    BOX3D b;
+
+    uint32_t d = 0;
+    uint32_t x = 0;
+    uint32_t y = 0;
+    uint32_t z = 0;
+
+    std::string toString() const
+    {
+        return std::to_string(d) + '-' + std::to_string(x) + '-' +
+            std::to_string(y) + '-' + std::to_string(z);
+    }
+
+    double& operator[](uint64_t i)
+    {
+        switch (i)
+        {
+            case 0: return b.minx;
+            case 1: return b.miny;
+            case 2: return b.minz;
+            case 3: return b.maxx;
+            case 4: return b.maxy;
+            case 5: return b.maxz;
+            default: throw pdal_error("Invalid Key[] index");
+        }
+    }
+
+    uint32_t& idAt(uint64_t i)
+    {
+        switch (i)
+        {
+            case 0: return x;
+            case 1: return y;
+            case 2: return z;
+            default: throw pdal_error("Invalid Key::idAt index");
+        }
+    }
+
+    Key bisect(uint64_t direction) const
+    {
+        Key key(*this);
+        ++key.d;
+
+        auto step([&key, direction](uint8_t i)
+        {
+            key.idAt(i) *= 2;
+
+            const double mid(key[i] + (key[i + 3] - key[i]) / 2.0);
+            const bool positive(direction & (((uint64_t)1) << i));
+            if (positive)
+            {
+                key[i] = mid;
+                ++key.idAt(i);
+            }
+            else
+            {
+                key[i + 3] = mid;
+            }
+        });
+
+        for (uint8_t i(0); i < 3; ++i)
+            step(i);
+
+        return key;
+    }
+};
+
+inline bool operator==(const Key& a, const Key& b)
+{
+    return a.d == b.d && a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+inline bool operator<(const Key& a, const Key& b)
+{
+    if (a.d < b.d) return true;
+    if (a.d > b.d) return false;
+
+    if (a.x < b.x) return true;
+    if (a.x > b.x) return false;
+
+    if (a.y < b.y) return true;
+    if (a.y > b.y) return false;
+
+    if (a.z < b.z) return true;
+    return false;
+}
+
+} // namespace pdal
+
+namespace std
+{
+    template<>
+    struct hash<pdal::Key>
+    {
+        std::size_t operator()(pdal::Key const& k) const noexcept
+        {
+            std::hash<uint64_t> h;
+
+            uint64_t k1 = ((uint64_t)k.d << 32) | k.x;
+            uint64_t k2 = ((uint64_t)k.y << 32) | k.z;
+            return h(k1) ^ (h(k2) << 1);
+        }
+    };
+}
+

--- a/cachedept/io/private/ept/Overlap.hpp
+++ b/cachedept/io/private/ept/Overlap.hpp
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * Copyright (c) 2018, Connor Manning
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <unordered_set>
+
+#include "Key.hpp"
+
+namespace pdal
+{
+
+struct Overlap
+{
+    Overlap(const Key& key) : m_key(key), m_count(0), m_nodeId(0)
+    {}
+    Overlap(const Key& key, point_count_t count, uint64_t nodeId) :
+        m_key(key), m_count(count), m_nodeId(nodeId)
+    {}
+
+    Key m_key;
+    point_count_t m_count;
+    uint64_t m_nodeId;
+};
+using Hierarchy = std::unordered_set<Overlap>;
+
+inline bool operator==(const Overlap& a, const Overlap& b)
+{
+    return a.m_key == b.m_key;
+}
+
+} // namespace pdal
+
+namespace std
+{
+    template<>
+    struct hash<pdal::Overlap>
+    {
+        std::size_t operator()(const pdal::Overlap& o) const noexcept
+        {
+            return std::hash<pdal::Key>{}(o.m_key);
+        }
+    };
+}
+

--- a/cachedept/io/private/ept/TileContents.cpp
+++ b/cachedept/io/private/ept/TileContents.cpp
@@ -1,0 +1,183 @@
+/******************************************************************************
+ * Copyright (c) 2020, Hobu Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include <io/LasReader.hpp>
+#include <pdal/compression/ZstdCompression.hpp>
+
+#include "Connector.hpp"
+#include "EptInfo.hpp"
+#include "TileContents.hpp"
+#include "VectorPointTable.hpp"
+
+namespace pdal
+{
+
+void TileContents::read()
+{
+    try
+    {
+        if (m_info.dataType() == EptInfo::DataType::Laszip)
+            readLaszip();
+        else if (m_info.dataType() == EptInfo::DataType::Binary)
+            readBinary();
+#ifdef PDAL_HAVE_ZSTD
+        else if (m_info.dataType() == EptInfo::DataType::Zstandard)
+            readZstandard();
+#endif
+        else
+            throw pdal_error("Unrecognized EPT dataType");
+//ABELL - Should check that we read the number of points specified in the
+//  overlap.
+        // Read addon information after the native data, we'll possibly
+        // overwrite attributes.
+        for (const Addon& addon : m_addons)
+            readAddon(addon);
+    }
+    catch (const std::exception& ex)
+    {
+        m_error = ex.what();
+    }
+    catch (...)
+    {
+        m_error = "Unknown exception when reading tile contents";
+    }
+}
+
+void TileContents::readLaszip()
+{
+    // If the file is remote (HTTP, S3, Dropbox, etc.), getLocalHandle will
+    // download the file and `localPath` will return the location of the
+    // downloaded file in a temporary directory.  Otherwise it's a no-op.
+    std::string filename = m_info.dataDir() + key().toString() + ".laz";
+    auto handle = m_connector.getLocalHandle(filename);
+
+    m_table.reset(new ColumnPointTable);
+
+    Options options;
+    options.add("filename", handle.localPath());
+    options.add("use_eb_vlr", true);
+    options.add("nosrs", true);
+
+    LasReader reader;
+    reader.setOptions(options);
+
+    reader.prepare(*m_table);
+    reader.execute(*m_table);
+}
+
+void TileContents::readBinary()
+{
+    std::string filename = m_info.dataDir() + key().toString() + ".bin";
+    auto data(m_connector.getBinary(filename));
+
+    VectorPointTable *vpt = new VectorPointTable(m_info.remoteLayout());
+    vpt->buffer() = std::move(data);
+    m_table.reset(vpt);
+
+    transform();
+}
+
+#ifdef PDAL_HAVE_ZSTD
+void TileContents::readZstandard()
+{
+    std::string filename = m_info.dataDir() + key().toString() + ".zst";
+    auto compressed(m_connector.getBinary(filename));
+    std::vector<char> data;
+    pdal::ZstdDecompressor dec([&data](char* pos, std::size_t size)
+    {
+        data.insert(data.end(), pos, pos + size);
+    });
+
+    dec.decompress(compressed.data(), compressed.size());
+
+    VectorPointTable *vpt = new VectorPointTable(m_info.remoteLayout());
+    vpt->buffer() = std::move(data);
+    m_table.reset(vpt);
+
+    transform();
+}
+#else
+void TileContents::readZstandard()
+{}
+#endif // PDAL_HAVE_ZSTD
+
+void TileContents::readAddon(const Addon& addon)
+{
+    m_addonTables[addon.localId()] = nullptr;
+
+    point_count_t addonPoints = addon.points(key());
+    if (addonPoints == 0)
+        return;
+
+    // If the addon hierarchy exists, it must match the EPT data.
+    if (addonPoints != size())
+        throw pdal_error("Invalid addon hierarchy");
+
+    std::string filename = addon.dataDir() + key().toString() + ".bin";
+    const auto data(m_connector.getBinary(filename));
+
+    if (size() * Dimension::size(addon.type()) != data.size())
+        throw pdal_error("Invalid addon content length");
+
+    VectorPointTable *vpt = new VectorPointTable(addon.layout());
+    vpt->buffer() = std::move(data);
+    m_addonTables[addon.localId()] = BasePointTablePtr(vpt);
+}
+
+void TileContents::transform()
+{
+    using D = Dimension::Id;
+
+    // Shorten long name.
+    const XForm& xf = m_info.dimType(Dimension::Id::X).m_xform;
+    const XForm& yf = m_info.dimType(Dimension::Id::Y).m_xform;
+    const XForm& zf = m_info.dimType(Dimension::Id::Z).m_xform;
+
+    PointRef p(*m_table);
+    for (PointId i = 0; i < size(); ++i)
+    {
+        p.setPointId(i);
+
+        // Scale the XYZ values.
+        p.setField(D::X, p.getFieldAs<double>(D::X) * xf.m_scale.m_val +
+            xf.m_offset.m_val);
+        p.setField(D::Y, p.getFieldAs<double>(D::Y) * yf.m_scale.m_val +
+            yf.m_offset.m_val);
+        p.setField(D::Z, p.getFieldAs<double>(D::Z) * zf.m_scale.m_val +
+            zf.m_offset.m_val);
+    }
+}
+
+} // namespace pdal
+

--- a/cachedept/io/private/ept/TileContents.hpp
+++ b/cachedept/io/private/ept/TileContents.hpp
@@ -1,0 +1,97 @@
+/******************************************************************************
+ * Copyright (c) 2020, Hobu Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <pdal/PointView.hpp>
+#include <pdal/pdal_types.hpp>
+
+#include "Addon.hpp"
+#include "Overlap.hpp"
+
+namespace pdal
+{
+
+class EptInfo;
+class Connector;
+class BasePointTable;
+using BasePointTablePtr = std::unique_ptr<BasePointTable>;
+
+class TileContents
+{
+public:
+    TileContents(const Overlap& overlap, const EptInfo& info,
+            const Connector& connector, const AddonList& addons) :
+        m_overlap(overlap), m_info(info), m_connector(connector),
+        m_addons(addons)
+    {}
+
+    BasePointTable& table() const
+        { return *m_table; }
+    const Key& key() const
+        { return m_overlap.m_key; }
+    point_count_t nodeId() const
+        { return m_overlap.m_nodeId; }
+    //ABELL - This is bad. We're assuming that the actual number of points we have matches
+    // what our index information told us. This may not be the case because of some
+    // issue. Downstream handling may depend on this being the actual number of points
+    // in the tile, rather than the number that were *supposed to be* in the tile.
+    point_count_t size() const
+        { return m_overlap.m_count; }
+    const std::string& error() const
+        { return m_error; }
+    BasePointTable *addonTable(Dimension::Id id) const
+        { return const_cast<TileContents *>(this)->m_addonTables[id].get(); }
+    void read();
+
+private:
+    Overlap m_overlap;
+    const EptInfo& m_info;
+    const Connector& m_connector;
+    const AddonList& m_addons;
+    std::string m_error;
+    // Table for the base point data.
+    BasePointTablePtr m_table;
+    // Tables for the add on data.
+    std::map<Dimension::Id, BasePointTablePtr> m_addonTables;
+
+    void readLaszip();
+    void readBinary();
+    void readZstandard();
+    void readAddon(const Addon& addon);
+    void transform();
+};
+
+} // namespace pdal
+

--- a/cachedept/io/private/ept/VectorPointTable.hpp
+++ b/cachedept/io/private/ept/VectorPointTable.hpp
@@ -1,0 +1,66 @@
+/******************************************************************************
+ * Copyright (c) 2018, Connor Manning
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <pdal/PointTable.hpp>
+
+namespace pdal
+{
+
+class PDAL_DLL VectorPointTable : public SimplePointTable
+{
+public:
+    VectorPointTable(PointLayout& layout) : SimplePointTable(layout)
+    {}
+
+    virtual PointId addPoint() override
+        { return 0; }
+    virtual bool supportsView() const override
+        { return true; }
+    std::size_t numPoints() const
+        { return m_buffer.size() / m_layoutRef.pointSize(); }
+    std::vector<char>& buffer()
+        { return m_buffer; }
+
+protected:
+    virtual char* getPoint(PointId id) override
+        { return m_buffer.data() + pointsToBytes(id); }
+
+private:
+    std::vector<char> m_buffer;
+};
+
+} // namespace pdal
+

--- a/cachedept/io/private/thread-safe-lru/hash.h
+++ b/cachedept/io/private/thread-safe-lru/hash.h
@@ -1,0 +1,282 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - The x86 and x64 versions do _not_ produce the same results, as the
+// algorithms are optimized for their respective platforms. You can still
+// compile and run any of them on any platform, but your performance with the
+// non-native version will be less than optimal.
+//
+// Adapted for thread-safe-lru by Tim Starling. All modifications are placed in
+// the public domain.
+
+#ifndef incl_tstarling_HASH_H
+#define incl_tstarling_HASH_H
+
+#include <stdint.h>
+
+namespace tstarling {
+namespace MurmurHash3 {
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+inline uint32_t rotl32 ( uint32_t x, int8_t r )
+{
+  return (x << r) | (x >> (32 - r));
+}
+
+inline uint64_t rotl64 ( uint64_t x, int8_t r )
+{
+  return (x << r) | (x >> (64 - r));
+}
+
+#define ROTL32(x,y) rotl32(x,y)
+#define ROTL64(x,y) rotl64(x,y)
+
+//-----------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
+
+inline uint32_t getblock32 ( const uint32_t * p, int i )
+{
+  return p[i];
+}
+
+inline uint64_t getblock64(const uint64_t* p, int i)
+{
+  return p[i];
+}
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+inline uint32_t fmix32(uint32_t h)
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+//----------
+
+inline uint64_t fmix64(uint64_t k)
+{
+  k ^= k >> 33;
+  k *= 0xff51afd7ed558ccdLLU;
+  k ^= k >> 33;
+  k *= 0xc4ceb9fe1a85ec53LLU;
+  k ^= k >> 33;
+
+  return k;
+}
+
+//-----------------------------------------------------------------------------
+
+inline static void hash_x86_128 ( const void * key, const int len,
+                           uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+
+  uint32_t h1 = seed;
+  uint32_t h2 = seed;
+  uint32_t h3 = seed;
+  uint32_t h4 = seed;
+
+  const uint32_t c1 = 0x239b961b; 
+  const uint32_t c2 = 0xab0e9789;
+  const uint32_t c3 = 0x38b34ae5; 
+  const uint32_t c4 = 0xa1e38b93;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
+
+  for(int i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock32(blocks,i*4+0);
+    uint32_t k2 = getblock32(blocks,i*4+1);
+    uint32_t k3 = getblock32(blocks,i*4+2);
+    uint32_t k4 = getblock32(blocks,i*4+3);
+
+    k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL32(h1,19); h1 += h2; h1 = h1*5+0x561ccd1b;
+
+    k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+    h2 = ROTL32(h2,17); h2 += h3; h2 = h2*5+0x0bcaa747;
+
+    k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+    h3 = ROTL32(h3,15); h3 += h4; h3 = h3*5+0x96cd1c35;
+
+    k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+    h4 = ROTL32(h4,13); h4 += h1; h4 = h4*5+0x32ac3b17;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint32_t k1 = 0;
+  uint32_t k2 = 0;
+  uint32_t k3 = 0;
+  uint32_t k4 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k4 ^= tail[14] << 16;
+  case 14: k4 ^= tail[13] << 8;
+  case 13: k4 ^= tail[12] << 0;
+           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+  case 12: k3 ^= tail[11] << 24;
+  case 11: k3 ^= tail[10] << 16;
+  case 10: k3 ^= tail[ 9] << 8;
+  case  9: k3 ^= tail[ 8] << 0;
+           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+  case  8: k2 ^= tail[ 7] << 24;
+  case  7: k2 ^= tail[ 6] << 16;
+  case  6: k2 ^= tail[ 5] << 8;
+  case  5: k2 ^= tail[ 4] << 0;
+           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+  case  4: k1 ^= tail[ 3] << 24;
+  case  3: k1 ^= tail[ 2] << 16;
+  case  2: k1 ^= tail[ 1] << 8;
+  case  1: k1 ^= tail[ 0] << 0;
+           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len;
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  h1 = fmix32(h1);
+  h2 = fmix32(h2);
+  h3 = fmix32(h3);
+  h4 = fmix32(h4);
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  ((uint32_t*)out)[0] = h1;
+  ((uint32_t*)out)[1] = h2;
+  ((uint32_t*)out)[2] = h3;
+  ((uint32_t*)out)[3] = h4;
+}
+
+//-----------------------------------------------------------------------------
+
+inline static void hash_x64_128 ( const void * key, const int len,
+                           const uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  const uint64_t c1 = 0x87c37b91114253d5LLU;
+  const uint64_t c2 = 0x4cf5ad432745937fLLU;
+
+  //----------
+  // body
+
+  const uint64_t * blocks = (const uint64_t *)(data);
+
+  for(int i = 0; i < nblocks; i++)
+  {
+    uint64_t k1 = getblock64(blocks,i*2+0);
+    uint64_t k2 = getblock64(blocks,i*2+1);
+
+    k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL64(h1,27); h1 += h2; h1 = h1*5+0x52dce729;
+
+    k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+    h2 = ROTL64(h2,31); h2 += h1; h2 = h2*5+0x38495ab5;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k2 ^= ((uint64_t)tail[14]) << 48;
+  case 14: k2 ^= ((uint64_t)tail[13]) << 40;
+  case 13: k2 ^= ((uint64_t)tail[12]) << 32;
+  case 12: k2 ^= ((uint64_t)tail[11]) << 24;
+  case 11: k2 ^= ((uint64_t)tail[10]) << 16;
+  case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;
+  case  9: k2 ^= ((uint64_t)tail[ 8]) << 0;
+           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+  case  8: k1 ^= ((uint64_t)tail[ 7]) << 56;
+  case  7: k1 ^= ((uint64_t)tail[ 6]) << 48;
+  case  6: k1 ^= ((uint64_t)tail[ 5]) << 40;
+  case  5: k1 ^= ((uint64_t)tail[ 4]) << 32;
+  case  4: k1 ^= ((uint64_t)tail[ 3]) << 24;
+  case  3: k1 ^= ((uint64_t)tail[ 2]) << 16;
+  case  2: k1 ^= ((uint64_t)tail[ 1]) << 8;
+  case  1: k1 ^= ((uint64_t)tail[ 0]) << 0;
+           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  ((uint64_t*)out)[0] = h1;
+  ((uint64_t*)out)[1] = h2;
+}
+
+// HHVM-compatible interface
+template <bool unused>
+inline void hash128 ( const void * key, const int len,
+                           const uint32_t seed, uint64_t out[2] )
+{
+  if (std::numeric_limits<size_t>::digits == 32) {
+    hash_x86_128(key, len, seed, (void*)out);
+  } else {
+    hash_x64_128(key, len, seed, (void*)out);
+  }
+}
+
+
+//-----------------------------------------------------------------------------
+
+} // namespace MurmurHash3
+} // namespace tstarling
+
+#endif

--- a/cachedept/io/private/thread-safe-lru/lru-cache.h
+++ b/cachedept/io/private/thread-safe-lru/lru-cache.h
@@ -1,0 +1,393 @@
+/*
+ * Copyright (c) 2014 Tim Starling
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef incl_tstarling_LRU_CACHE_H
+#define incl_tstarling_LRU_CACHE_H
+
+#include <atomic>
+#include <mutex>
+#include <new>
+#include <thread>
+#include <vector>
+#include <tbb/concurrent_hash_map.h>
+
+namespace tstarling {
+
+/**
+ * ThreadSafeLRUCache is a thread-safe hashtable with a limited size. When
+ * it is full, insert() evicts the least recently used item from the cache.
+ *
+ * The find() operation fills a ConstAccessor object, which is a smart pointer
+ * similar to TBB's const_accessor. After eviction, destruction of the value is
+ * deferred until all ConstAccessor objects are destroyed.
+ *
+ * The implementation is generally conservative, relying on the documented
+ * behaviour of tbb::concurrent_hash_map. LRU list transactions are protected
+ * with a single mutex. Having our own doubly-linked list implementation helps
+ * to ensure that list transactions are sufficiently brief, consisting of only
+ * a few loads and stores. User code is not executed while the lock is held.
+ *
+ * The acquisition of the list mutex during find() is non-blocking (try_lock),
+ * so under heavy lookup load, the container will not stall, instead some LRU
+ * update operations will be omitted.
+ *
+ * Insert performance was observed to degrade rapidly when there is a heavy
+ * concurrent insert/evict load, mostly due to locks in the underlying
+ * TBB::CHM. So if that is a possibility for your workload,
+ * ThreadSafeScalableCache is recommended instead.
+ */
+template <class TKey, class TValue, class THash = tbb::tbb_hash_compare<TKey>>
+class ThreadSafeLRUCache {
+  /**
+   * The LRU list node.
+   *
+   * We make a copy of the key in the list node, allowing us to find the
+   * TBB::CHM element from the list node. TBB::CHM invalidates iterators
+   * on most operations, even find(), ruling out more efficient
+   * implementations.
+   */
+  struct ListNode {
+    ListNode()
+      : m_prev(OutOfListMarker), m_next(nullptr)
+    {}
+
+    ListNode(const TKey& key)
+      : m_key(key), m_prev(OutOfListMarker), m_next(nullptr)
+    {}
+
+    TKey m_key;
+    ListNode* m_prev;
+    ListNode* m_next;
+
+    bool isInList() const {
+      return m_prev != OutOfListMarker;
+    }
+  };
+
+  static ListNode* const OutOfListMarker;
+
+  /**
+   * The value that we store in the hashtable. The list node is allocated from
+   * an internal object_pool. The ListNode* is owned by the list.
+   */
+  struct HashMapValue {
+    HashMapValue()
+      : m_listNode(nullptr)
+    {}
+    
+    HashMapValue(const TValue& value, ListNode* node)
+      : m_value(value), m_listNode(node)
+    {}
+
+    TValue m_value;
+    ListNode* m_listNode;
+  };
+
+  typedef tbb::concurrent_hash_map<TKey, HashMapValue, THash> HashMap;
+  typedef typename HashMap::const_accessor HashMapConstAccessor;
+  typedef typename HashMap::accessor HashMapAccessor;
+  typedef typename HashMap::value_type HashMapValuePair;
+  typedef std::pair<const TKey, TValue> SnapshotValue;
+
+public:
+  /**
+   * The proxy object for TBB::CHM::const_accessor. Provides direct access to
+   * the user's value by dereferencing, thus hiding our implementation
+   * details.
+   */
+  struct ConstAccessor {
+    ConstAccessor() {}
+
+    const TValue& operator*() const {
+      return *get();
+    }
+
+    const TValue* operator->() const {
+      return get();
+    }
+
+    const TValue* get() const {
+      return &m_hashAccessor->second.m_value;
+    }
+
+    bool empty() const {
+      return m_hashAccessor.empty();
+    }
+
+  private:
+    friend class ThreadSafeLRUCache;
+    HashMapConstAccessor m_hashAccessor;
+  };
+
+  /**
+   * Create a container with a given maximum size
+   */
+  explicit ThreadSafeLRUCache(size_t maxSize);
+
+  ThreadSafeLRUCache(const ThreadSafeLRUCache& other) = delete;
+  ThreadSafeLRUCache& operator=(const ThreadSafeLRUCache&) = delete;
+
+  ~ThreadSafeLRUCache() {
+    clear();
+  }
+
+  /**
+   * Find a value by key, and return it by filling the ConstAccessor, which
+   * can be default-constructed. Returns true if the element was found, false
+   * otherwise. Updates the eviction list, making the element the
+   * most-recently used.
+   */
+  bool find(ConstAccessor& ac, const TKey& key);
+
+  /**
+   * Insert a value into the container. Both the key and value will be copied.
+   * The new element will put into the eviction list as the most-recently
+   * used.
+   *
+   * If there was already an element in the container with the same key, it
+   * will not be updated, and false will be returned. Otherwise, true will be
+   * returned.
+   */
+  bool insert(const TKey& key, const TValue& value);
+
+  /**
+   * Clear the container. NOT THREAD SAFE -- do not use while other threads
+   * are accessing the container.
+   */
+  void clear();
+
+  /**
+   * Get a snapshot of the keys in the container by copying them into the
+   * supplied vector. This will block inserts and prevent LRU updates while it
+   * completes. The keys will be inserted in order from most-recently used to
+   * least-recently used.
+   */
+  void snapshotKeys(std::vector<TKey>& keys);
+
+  /**
+   * Get the approximate size of the container. May be slightly too low when
+   * insertion is in progress.
+   */
+  size_t size() const {
+    return m_size.load();
+  }
+
+private:
+  /**
+   * Unlink a node from the list. The caller must lock the list mutex while
+   * this is called.
+   */
+  void delink(ListNode* node);
+
+  /**
+   * Add a new node to the list in the most-recently used position. The caller
+   * must lock the list mutex while this is called.
+   */
+  void pushFront(ListNode* node);
+
+  /**
+   * Evict the least-recently used item from the container. This function does
+   * its own locking.
+   */
+  void evict();
+
+  /**
+   * The maximum number of elements in the container.
+   */
+  size_t m_maxSize;
+
+  /**
+   * This atomic variable is used to signal to all threads whether or not
+   * eviction should be done on insert. It is approximately equal to the
+   * number of elements in the container.
+   */
+  std::atomic<size_t> m_size;
+
+  /** 
+   * The underlying TBB hash map.
+   */
+  HashMap m_map;
+
+  /**
+   * The linked list. The "head" is the most-recently used node, and the
+   * "tail" is the least-recently used node. The list mutex must be held
+   * during both read and write.
+   */
+  ListNode m_head;
+  ListNode m_tail;
+  typedef std::mutex ListMutex;
+  ListMutex m_listMutex;
+};
+
+template <class TKey, class TValue, class THash>
+typename ThreadSafeLRUCache<TKey, TValue, THash>::ListNode* const
+ThreadSafeLRUCache<TKey, TValue, THash>::OutOfListMarker = (ListNode*)-1;
+
+template <class TKey, class TValue, class THash>
+ThreadSafeLRUCache<TKey, TValue, THash>::
+ThreadSafeLRUCache(size_t maxSize)
+  : m_maxSize(maxSize), m_size(0),
+  m_map(std::thread::hardware_concurrency() * 4) // it will automatically grow
+{
+  m_head.m_prev = nullptr;
+  m_head.m_next = &m_tail;
+  m_tail.m_prev = &m_head;
+}
+
+template <class TKey, class TValue, class THash>
+bool ThreadSafeLRUCache<TKey, TValue, THash>::
+find(ConstAccessor& ac, const TKey& key) {
+  HashMapConstAccessor& hashAccessor = ac.m_hashAccessor;
+  if (!m_map.find(hashAccessor, key)) {
+    return false;
+  }
+
+  // Acquire the lock, but don't block if it is already held
+  std::unique_lock<ListMutex> lock(m_listMutex, std::try_to_lock);
+  if (lock) {
+    ListNode* node = hashAccessor->second.m_listNode;
+    // The list node may be out of the list if it is in the process of being
+    // inserted or evicted. Doing this check allows us to lock the list for
+    // shorter periods of time.
+    if (node->isInList()) {
+      delink(node);
+      pushFront(node);
+    }
+    lock.unlock();
+  }
+  return true;
+}
+
+template <class TKey, class TValue, class THash>
+bool ThreadSafeLRUCache<TKey, TValue, THash>::
+insert(const TKey& key, const TValue& value) {
+  // Insert into the CHM
+  ListNode* node = new ListNode(key);
+  HashMapAccessor hashAccessor;
+  HashMapValuePair hashMapValue(key, HashMapValue(value, node));
+  if (!m_map.insert(hashAccessor, hashMapValue)) {
+    delete node;
+    return false;
+  }
+
+  // Evict if necessary, now that we know the hashmap insertion was successful.
+  size_t size = m_size.load();
+  bool evictionDone = false;
+  if (size >= m_maxSize) {
+    // The container is at (or over) capacity, so eviction needs to be done.
+    // Do not decrement m_size, since that would cause other threads to
+    // inappropriately omit eviction during their own inserts.
+    evict();
+    evictionDone = true;
+  }
+
+  // Note that we have to update the LRU list before we increment m_size, so
+  // that other threads don't attempt to evict list items before they even
+  // exist.
+  std::unique_lock<ListMutex> lock(m_listMutex);
+  pushFront(node);
+  lock.unlock();
+  if (!evictionDone) {
+    size = m_size++;
+  }
+  if (size > m_maxSize) {
+    // It is possible for the size to temporarily exceed the maximum if there is
+    // a heavy insert() load, once only as the cache fills. In this situation,
+    // we have to be careful not to have every thread simultaneously attempt to
+    // evict the extra entries, since we could end up underfilled. Instead we do
+    // a compare-and-exchange to acquire an exclusive right to reduce the size
+    // to a particular value.
+    //
+    // We could continue to evict in a loop, but if there are a lot of threads
+    // here at the same time, that could lead to spinning. So we will just evict
+    // one extra element per insert() until the overfill is rectified.
+    if (m_size.compare_exchange_strong(size, size - 1)) {
+      evict();
+    }
+  }
+  return true;
+}
+
+template <class TKey, class TValue, class THash>
+void ThreadSafeLRUCache<TKey, TValue, THash>::
+clear() {
+  m_map.clear();
+  ListNode* node = m_head.m_next;
+  ListNode* next;
+  while (node != &m_tail) {
+    next = node->m_next;
+    delete node;
+    node = next;
+  }
+  m_head.m_next = &m_tail;
+  m_tail.m_prev = &m_head;
+  m_size = 0;
+}
+
+template <class TKey, class TValue, class THash>
+void ThreadSafeLRUCache<TKey, TValue, THash>::
+snapshotKeys(std::vector<TKey>& keys) {
+  keys.reserve(keys.size() + m_size.load());
+  std::lock_guard<ListMutex> lock(m_listMutex);
+  for (ListNode* node = m_head.m_next; node != &m_tail; node = node->m_next) {
+    keys.push_back(node->m_key);
+  }
+}
+
+template <class TKey, class TValue, class THash>
+inline void ThreadSafeLRUCache<TKey, TValue, THash>::
+delink(ListNode* node) {
+  ListNode* prev = node->m_prev;
+  ListNode* next = node->m_next;
+  prev->m_next = next;
+  next->m_prev = prev;
+  node->m_prev = OutOfListMarker;
+}
+
+template <class TKey, class TValue, class THash>
+inline void ThreadSafeLRUCache<TKey, TValue, THash>::
+pushFront(ListNode* node) {
+  ListNode* oldRealHead = m_head.m_next;
+  node->m_prev = &m_head;
+  node->m_next = oldRealHead;
+  oldRealHead->m_prev = node;
+  m_head.m_next = node;
+}
+
+template <class TKey, class TValue, class THash>
+void ThreadSafeLRUCache<TKey, TValue, THash>::
+evict() {
+  std::unique_lock<ListMutex> lock(m_listMutex);
+  ListNode* moribund = m_tail.m_prev;
+  if (moribund == &m_head) {
+    // List is empty, can't evict
+    return;
+  }
+  delink(moribund);
+  lock.unlock();
+
+  HashMapAccessor hashAccessor;
+  if (!m_map.find(hashAccessor, moribund->m_key)) {
+    // Presumably unreachable
+    return;
+  }
+  m_map.erase(hashAccessor);
+  delete moribund;
+}
+
+} // namespace tstarling
+
+#endif

--- a/cachedept/io/private/thread-safe-lru/scalable-cache.h
+++ b/cachedept/io/private/thread-safe-lru/scalable-cache.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2014 Tim Starling
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef incl_tstarling_SCALABLE_CACHE_H
+#define incl_tstarling_SCALABLE_CACHE_H
+
+#include "private/thread-safe-lru/lru-cache.h"
+#include "private/thread-safe-lru/string-key.h"
+#include <limits>
+#include <memory>
+
+namespace tstarling {
+
+/**
+ * ThreadSafeScalableCache is a thread-safe sharded hashtable with limited
+ * size. When it is full, it evicts a rough approximation to the least recently
+ * used item.
+ *
+ * The find() operation fills a ConstAccessor object, which is a smart pointer
+ * similar to TBB's const_accessor. After eviction, destruction of the value is
+ * deferred until all ConstAccessor objects are destroyed.
+ * 
+ * Since the hash value of each key is requested multiple times, you should use
+ * a key with a memoized hash function. ThreadSafeStringKey is provided for
+ * this purpose.
+ */
+template <class TKey, class TValue, class THash = tbb::tbb_hash_compare<TKey>>
+struct ThreadSafeScalableCache {
+  using Shard = ThreadSafeLRUCache<TKey, TValue, THash>;
+  typedef typename Shard::ConstAccessor ConstAccessor;
+
+  /**
+   * Constructor
+   *   - maxSize: the maximum number of items in the container
+   *   - numShards: the number of child containers. If this is zero, the
+   *     "hardware concurrency" will be used (typically the logical processor
+   *     count).
+   */
+  explicit ThreadSafeScalableCache(size_t maxSize, size_t numShards = 0);
+
+  ThreadSafeScalableCache(const ThreadSafeScalableCache&) = delete;
+  ThreadSafeScalableCache& operator=(const ThreadSafeScalableCache&) = delete;
+
+  /**
+   * Find a value by key, and return it by filling the ConstAccessor, which
+   * can be default-constructed. Returns true if the element was found, false
+   * otherwise. Updates the eviction list, making the element the
+   * most-recently used.
+   */
+  bool find(ConstAccessor& ac, const TKey& key);
+
+  /**
+   * Insert a value into the container. Both the key and value will be copied.
+   * The new element will put into the eviction list as the most-recently
+   * used.
+   *
+   * If there was already an element in the container with the same key, it
+   * will not be updated, and false will be returned. Otherwise, true will be
+   * returned.
+   */
+  bool insert(const TKey& key, const TValue& value);
+
+  /**
+   * Clear the container. NOT THREAD SAFE -- do not use while other threads
+   * are accessing the container.
+   */
+  void clear();
+
+  /**
+   * Get a snapshot of the keys in the container by copying them into the
+   * supplied vector. This will block inserts and prevent LRU updates while it
+   * completes. The keys will be inserted in a random order.
+   */
+  void snapshotKeys(std::vector<TKey>& keys);
+
+  /**
+   * Get the approximate size of the container. May be slightly too low when
+   * insertion is in progress.
+   */
+  size_t size() const;
+
+private:
+  /**
+   * Get the child container for a given key
+   */
+  Shard& getShard(const TKey& key);
+
+  /**
+   * The maximum number of elements in the container.
+   */
+  size_t m_maxSize;
+
+  /**
+   * The child containers
+   */
+  size_t m_numShards;
+  typedef std::shared_ptr<Shard> ShardPtr;
+  std::vector<ShardPtr> m_shards;
+};
+
+/**
+ * A specialisation of ThreadSafeScalableCache providing a cache with efficient
+ * string keys.
+ */
+template <class TValue>
+using ThreadSafeStringCache = ThreadSafeScalableCache<
+    ThreadSafeStringKey, TValue, ThreadSafeStringKey::HashCompare>;
+
+template <class TKey, class TValue, class THash>
+ThreadSafeScalableCache<TKey, TValue, THash>::
+ThreadSafeScalableCache(size_t maxSize, size_t numShards)
+  : m_maxSize(maxSize), m_numShards(numShards)
+{
+  if (m_numShards == 0) {
+    m_numShards = std::thread::hardware_concurrency();
+  }
+  for (size_t i = 0; i < m_numShards; i++) {
+    size_t s = maxSize / m_numShards;
+    if (i == 0) {
+      s += maxSize % m_numShards;
+    }
+    m_shards.emplace_back(std::make_shared<Shard>(s));
+  }
+}
+
+template <class TKey, class TValue, class THash>
+typename ThreadSafeScalableCache<TKey, TValue, THash>::Shard&
+ThreadSafeScalableCache<TKey, TValue, THash>::
+getShard(const TKey& key) {
+  THash hashObj;
+  constexpr int shift = std::numeric_limits<size_t>::digits - 16;
+  size_t h = (hashObj.hash(key) >> shift) % m_numShards;
+  return *m_shards.at(h);
+}
+
+template <class TKey, class TValue, class THash>
+bool ThreadSafeScalableCache<TKey, TValue, THash>::
+find(ConstAccessor& ac, const TKey& key) {
+  return getShard(key).find(ac, key);
+}
+
+template <class TKey, class TValue, class THash>
+bool ThreadSafeScalableCache<TKey, TValue, THash>::
+insert(const TKey& key, const TValue& value) {
+  return getShard(key).insert(key, value);
+}
+
+template <class TKey, class TValue, class THash>
+void ThreadSafeScalableCache<TKey, TValue, THash>::
+clear() {
+  for (size_t i = 0; i < m_numShards; i++) {
+    m_shards[i]->clear();
+  }
+}
+
+template <class TKey, class TValue, class THash>
+void ThreadSafeScalableCache<TKey, TValue, THash>::
+snapshotKeys(std::vector<TKey>& keys) {
+  for (size_t i = 0; i < m_numShards; i++) {
+    m_shards[i]->snapshotKeys(keys);
+  }
+}
+
+template <class TKey, class TValue, class THash>
+size_t ThreadSafeScalableCache<TKey, TValue, THash>::
+size() const {
+  size_t size;
+  for (size_t i = 0; i < m_numShards; i++) {
+    size += m_shards[i]->size();
+  }
+  return size;
+}
+
+} // namespace tstarling
+
+#endif

--- a/cachedept/io/private/thread-safe-lru/string-key.h
+++ b/cachedept/io/private/thread-safe-lru/string-key.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2014 Tim Starling
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef incl_tstarling_STRING_KEY_H
+#define incl_tstarling_STRING_KEY_H
+
+#include <atomic>
+#include <cstring>
+#include <limits>
+#include <memory>
+
+#include "private/thread-safe-lru/hash.h"
+
+namespace tstarling {
+
+struct ThreadSafeStringKey {
+  ThreadSafeStringKey(const char* data, size_t size)
+    : m_storage(new Storage(data, size))
+  {}
+
+  ThreadSafeStringKey() {}
+
+  uint64_t hash() const {
+    return m_storage->hash();
+  }
+
+  size_t size() const {
+    return m_storage->m_size;
+  }
+
+  const char* data() const {
+    return m_storage->m_data;
+  }
+
+  const char* c_str() const {
+    return data();
+  }
+
+  bool operator==(const ThreadSafeStringKey& other) const {
+    size_t s = size();
+    return s == other.size() && 0 == std::memcmp(data(), other.data(), s);
+  }
+
+  struct HashCompare {
+    bool equal(const ThreadSafeStringKey& j, const ThreadSafeStringKey& k) const {
+      return j == k;
+    }
+
+    size_t hash(const ThreadSafeStringKey& k) const {
+      return k.hash();
+    }
+  };
+
+private:
+  struct Storage {
+    Storage(const char* data, size_t size) 
+      : m_size(size), m_hash(0)
+    {
+      m_data = new char[size + 1];
+      memcpy(m_data, data, size);
+      m_data[size] = '\0';
+    }
+
+    ~Storage() {
+      delete[] m_data;
+    }
+
+    char* m_data;
+    size_t m_size;
+    mutable std::atomic<size_t> m_hash;
+
+    size_t hash() const {
+      size_t h = m_hash.load(std::memory_order_relaxed);
+      if (h == 0) {
+        uint64_t h128[2];
+        MurmurHash3::hash128<false>(m_data, m_size, 0, h128);
+        h = (size_t)h128[0];
+        if (h == 0) {
+          h = 1;
+        }
+        m_hash.store(h, std::memory_order_relaxed);
+      }
+      return h;
+    }
+  };
+
+  std::shared_ptr<Storage> m_storage;
+};
+
+} // namespace tstarling
+
+#endif

--- a/cmake/modules/FindTBB.cmake
+++ b/cmake/modules/FindTBB.cmake
@@ -1,0 +1,421 @@
+# - Find ThreadingBuildingBlocks include dirs and libraries
+# Use this module by invoking find_package with the form:
+#  find_package(TBB
+#    [REQUIRED]             # Fail with error if TBB is not found
+#    )                      #
+# Once done, this will define
+#
+#  TBB_FOUND - system has TBB
+#  TBB_INCLUDE_DIRS - the TBB include directories
+#  TBB_LIBRARIES - TBB libraries to be lined, doesn't include malloc or
+#                  malloc proxy
+#  TBB::tbb - imported target for the TBB library
+#
+#  TBB_VERSION_MAJOR - Major Product Version Number
+#  TBB_VERSION_MINOR - Minor Product Version Number
+#  TBB_INTERFACE_VERSION - Engineering Focused Version Number
+#  TBB_COMPATIBLE_INTERFACE_VERSION - The oldest major interface version
+#                                     still supported. This uses the engineering
+#                                     focused interface version numbers.
+#
+#  TBB_MALLOC_FOUND - system has TBB malloc library
+#  TBB_MALLOC_INCLUDE_DIRS - the TBB malloc include directories
+#  TBB_MALLOC_LIBRARIES - The TBB malloc libraries to be lined
+#  TBB::malloc - imported target for the TBB malloc library
+#
+#  TBB_MALLOC_PROXY_FOUND - system has TBB malloc proxy library
+#  TBB_MALLOC_PROXY_INCLUDE_DIRS = the TBB malloc proxy include directories
+#  TBB_MALLOC_PROXY_LIBRARIES - The TBB malloc proxy libraries to be lined
+#  TBB::malloc_proxy - imported target for the TBB malloc proxy library
+#
+#
+# This module reads hints about search locations from variables:
+#  ENV TBB_ARCH_PLATFORM - for eg. set it to "mic" for Xeon Phi builds
+#  ENV TBB_ROOT or just TBB_ROOT - root directory of tbb installation
+#  ENV TBB_BUILD_PREFIX - specifies the build prefix for user built tbb
+#                         libraries. Should be specified with ENV TBB_ROOT
+#                         and optionally...
+#  ENV TBB_BUILD_DIR - if build directory is different than ${TBB_ROOT}/build
+#
+#
+# Modified by Robert Maynard from the original OGRE source
+#
+#-------------------------------------------------------------------
+# This file is part of the CMake build system for OGRE
+#     (Object-oriented Graphics Rendering Engine)
+# For the latest info, see http://www.ogre3d.org/
+#
+# The contents of this file are placed in the public domain. Feel
+# free to make use of it in any way you like.
+#-------------------------------------------------------------------
+#
+# =========================================================================
+# Taken from Copyright.txt in the root of the VTK source tree as per
+# instructions to substitute the full license in place of the summary
+# reference when distributing outside of VTK
+# =========================================================================
+#
+#  Program:   Visualization Toolkit
+#  Module:    Copyright.txt
+#
+# Copyright (c) 1993-2015 Ken Martin, Will Schroeder, Bill Lorensen
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither name of Ken Martin, Will Schroeder, or Bill Lorensen nor the names
+#   of any contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# =========================================================================*/
+#=============================================================================
+#  FindTBB helper functions and macros
+#
+#====================================================
+# Fix the library path in case it is a linker script
+#====================================================
+function(tbb_extract_real_library library real_library)
+  if(NOT UNIX OR NOT EXISTS ${library})
+    set(${real_library} "${library}" PARENT_SCOPE)
+    return()
+  endif()
+  #Read in the first 4 bytes and see if they are the ELF magic number
+  set(_elf_magic "7f454c46")
+  file(READ ${library} _hex_data OFFSET 0 LIMIT 4 HEX)
+  if(_hex_data STREQUAL _elf_magic)
+    #we have opened a elf binary so this is what
+    #we should link to
+    set(${real_library} "${library}" PARENT_SCOPE)
+    return()
+  endif()
+  file(READ ${library} _data OFFSET 0 LIMIT 1024)
+  if("${_data}" MATCHES "INPUT \\(([^(]+)\\)")
+    #extract out the .so name from REGEX MATCH command
+    set(_proper_so_name "${CMAKE_MATCH_1}")
+    #construct path to the real .so which is presumed to be in the same directory
+    #as the input file
+    get_filename_component(_so_dir "${library}" DIRECTORY)
+    set(${real_library} "${_so_dir}/${_proper_so_name}" PARENT_SCOPE)
+  else()
+    #unable to determine what this library is so just hope everything works
+    #and pass it unmodified.
+    set(${real_library} "${library}" PARENT_SCOPE)
+  endif()
+endfunction()
+#===============================================
+# Do the final processing for the package find.
+#===============================================
+macro(findpkg_finish PREFIX TARGET_NAME)
+  if (${PREFIX}_INCLUDE_DIR AND ${PREFIX}_LIBRARY)
+    set(${PREFIX}_FOUND TRUE)
+    set (${PREFIX}_INCLUDE_DIRS ${${PREFIX}_INCLUDE_DIR})
+    set (${PREFIX}_LIBRARIES ${${PREFIX}_LIBRARY})
+  else ()
+    if (${PREFIX}_FIND_REQUIRED AND NOT ${PREFIX}_FIND_QUIETLY)
+      message(FATAL_ERROR "Required library ${PREFIX} not found.")
+    endif ()
+  endif ()
+  if (NOT TARGET "TBB::${TARGET_NAME}")
+    if (${PREFIX}_LIBRARY_RELEASE)
+      tbb_extract_real_library(${${PREFIX}_LIBRARY_RELEASE} real_release)
+    endif ()
+    if (${PREFIX}_LIBRARY_DEBUG)
+      tbb_extract_real_library(${${PREFIX}_LIBRARY_DEBUG} real_debug)
+    endif ()
+    add_library(TBB::${TARGET_NAME} UNKNOWN IMPORTED)
+    set_target_properties(TBB::${TARGET_NAME} PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${${PREFIX}_INCLUDE_DIR}")
+    if (${PREFIX}_LIBRARY_DEBUG AND ${PREFIX}_LIBRARY_RELEASE)
+      set_target_properties(TBB::${TARGET_NAME} PROPERTIES
+        IMPORTED_LOCATION "${real_release}"
+        IMPORTED_LOCATION_DEBUG "${real_debug}"
+        IMPORTED_LOCATION_RELEASE "${real_release}")
+    elseif (${PREFIX}_LIBRARY_RELEASE)
+      set_target_properties(TBB::${TARGET_NAME} PROPERTIES
+        IMPORTED_LOCATION "${real_release}")
+    elseif (${PREFIX}_LIBRARY_DEBUG)
+      set_target_properties(TBB::${TARGET_NAME} PROPERTIES
+        IMPORTED_LOCATION "${real_debug}")
+    endif ()
+  endif ()
+  #mark the following variables as internal variables
+  mark_as_advanced(${PREFIX}_INCLUDE_DIR
+                   ${PREFIX}_LIBRARY
+                   ${PREFIX}_LIBRARY_DEBUG
+                   ${PREFIX}_LIBRARY_RELEASE)
+endmacro()
+#===============================================
+# Generate debug names from given release names
+#===============================================
+macro(get_debug_names PREFIX)
+  foreach(i ${${PREFIX}})
+    set(${PREFIX}_DEBUG ${${PREFIX}_DEBUG} ${i}d ${i}D ${i}_d ${i}_D ${i}_debug ${i})
+  endforeach()
+endmacro()
+#===============================================
+# See if we have env vars to help us find tbb
+#===============================================
+macro(getenv_path VAR)
+   set(ENV_${VAR} $ENV{${VAR}})
+   # replace won't work if var is blank
+   if (ENV_${VAR})
+     string( REGEX REPLACE "\\\\" "/" ENV_${VAR} ${ENV_${VAR}} )
+   endif ()
+endmacro()
+#===============================================
+# Couple a set of release AND debug libraries
+#===============================================
+macro(make_library_set PREFIX)
+  if (${PREFIX}_RELEASE AND ${PREFIX}_DEBUG)
+    set(${PREFIX} optimized ${${PREFIX}_RELEASE} debug ${${PREFIX}_DEBUG})
+  elseif (${PREFIX}_RELEASE)
+    set(${PREFIX} ${${PREFIX}_RELEASE})
+  elseif (${PREFIX}_DEBUG)
+    set(${PREFIX} ${${PREFIX}_DEBUG})
+  endif ()
+endmacro()
+#===============================================
+# Ensure that the release & debug libraries found are from the same installation.
+#===============================================
+macro(find_tbb_library_verifying_release_debug_locations PREFIX)
+  find_library(${PREFIX}_RELEASE
+    NAMES ${${PREFIX}_NAMES}
+    HINTS ${TBB_LIB_SEARCH_PATH})
+  if (${PREFIX}_RELEASE)
+    # To avoid finding a mismatched set of release & debug libraries from
+    # different installations if the first found does not have debug libraries
+    # by forcing the search for debug to only occur within the detected release
+    # library directory (if found).  Although this would break detection if the
+    # release & debug libraries were shipped in different directories, this is
+    # not the case in the official TBB releases for any platform.
+    get_filename_component(
+      FOUND_RELEASE_LIB_DIR "${${PREFIX}_RELEASE}" DIRECTORY)
+    find_library(${PREFIX}_DEBUG
+      NAMES ${${PREFIX}_NAMES_DEBUG}
+      HINTS ${FOUND_RELEASE_LIB_DIR}
+      NO_DEFAULT_PATH)
+  else()
+    find_library(${PREFIX}_DEBUG
+      NAMES ${${PREFIX}_NAMES_DEBUG}
+      HINTS ${TBB_LIB_SEARCH_PATH})
+  endif()
+endmacro()
+#=============================================================================
+#  Now to actually find TBB
+#
+# Get path, convert backslashes as ${ENV_${var}}
+getenv_path(TBB_ROOT)
+# initialize search paths
+set(TBB_PREFIX_PATH ${TBB_ROOT} ${ENV_TBB_ROOT})
+set(TBB_INC_SEARCH_PATH "")
+set(TBB_LIB_SEARCH_PATH "")
+# If user built from sources
+set(TBB_BUILD_PREFIX $ENV{TBB_BUILD_PREFIX})
+if (TBB_BUILD_PREFIX AND ENV_TBB_ROOT)
+  getenv_path(TBB_BUILD_DIR)
+  if (NOT ENV_TBB_BUILD_DIR)
+    set(ENV_TBB_BUILD_DIR ${ENV_TBB_ROOT}/build)
+  endif ()
+  # include directory under ${ENV_TBB_ROOT}/include
+  list(APPEND TBB_LIB_SEARCH_PATH
+    ${ENV_TBB_BUILD_DIR}/${TBB_BUILD_PREFIX}_release
+    ${ENV_TBB_BUILD_DIR}/${TBB_BUILD_PREFIX}_debug)
+endif ()
+# For Windows, let's assume that the user might be using the precompiled
+# TBB packages from the main website. These use a rather awkward directory
+# structure (at least for automatically finding the right files) depending
+# on platform and compiler, but we'll do our best to accommodate it.
+# Not adding the same effort for the precompiled linux builds, though. Those
+# have different versions for CC compiler versions and linux kernels which
+# will never adequately match the user's setup, so there is no feasible way
+# to detect the "best" version to use. The user will have to manually
+# select the right files. (Chances are the distributions are shipping their
+# custom version of tbb, anyway, so the problem is probably nonexistent.)
+if (WIN32 AND MSVC)
+  set(COMPILER_PREFIX "vc7.1")
+  if (MSVC_VERSION EQUAL 1400)
+    set(COMPILER_PREFIX "vc8")
+  elseif(MSVC_VERSION EQUAL 1500)
+    set(COMPILER_PREFIX "vc9")
+  elseif(MSVC_VERSION EQUAL 1600)
+    set(COMPILER_PREFIX "vc10")
+  elseif(MSVC_VERSION EQUAL 1700)
+    set(COMPILER_PREFIX "vc11")
+  elseif(MSVC_VERSION EQUAL 1800)
+    set(COMPILER_PREFIX "vc12")
+  elseif(MSVC_VERSION GREATER_EQUAL 1900)
+    set(COMPILER_PREFIX "vc14")
+  endif ()
+  # for each prefix path, add ia32/64\${COMPILER_PREFIX}\lib to the lib search path
+  foreach (dir IN LISTS TBB_PREFIX_PATH)
+    if (CMAKE_CL_64)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia64/${COMPILER_PREFIX}/lib)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia64/${COMPILER_PREFIX})
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/intel64/${COMPILER_PREFIX}/lib)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/intel64/${COMPILER_PREFIX})
+    else ()
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia32/${COMPILER_PREFIX}/lib)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia32/${COMPILER_PREFIX})
+    endif ()
+  endforeach ()
+endif ()
+# For OS X binary distribution, choose libc++ based libraries for Mavericks (10.9)
+# and above and AppleClang
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND
+    NOT CMAKE_SYSTEM_VERSION VERSION_LESS 13.0)
+  set (USE_LIBCXX OFF)
+  cmake_policy(GET CMP0025 POLICY_VAR)
+  if (POLICY_VAR STREQUAL "NEW")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+      set (USE_LIBCXX ON)
+    endif ()
+  else ()
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      set (USE_LIBCXX ON)
+    endif ()
+  endif ()
+  if (USE_LIBCXX)
+    foreach (dir IN LISTS TBB_PREFIX_PATH)
+      list (APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/libc++ ${dir}/libc++/lib)
+    endforeach ()
+  endif ()
+endif ()
+# check compiler ABI
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(COMPILER_PREFIX)
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
+    list(APPEND COMPILER_PREFIX "gcc4.8")
+  endif()
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.7)
+    list(APPEND COMPILER_PREFIX "gcc4.7")
+  endif()
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)
+    list(APPEND COMPILER_PREFIX "gcc4.4")
+  endif()
+  list(APPEND COMPILER_PREFIX "gcc4.1")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(COMPILER_PREFIX)
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.0) # Complete guess
+    list(APPEND COMPILER_PREFIX "gcc4.8")
+  endif()
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6)
+    list(APPEND COMPILER_PREFIX "gcc4.7")
+  endif()
+  list(APPEND COMPILER_PREFIX "gcc4.4")
+else() # Assume compatibility with 4.4 for other compilers
+  list(APPEND COMPILER_PREFIX "gcc4.4")
+endif ()
+# if platform architecture is explicitly specified
+set(TBB_ARCH_PLATFORM $ENV{TBB_ARCH_PLATFORM})
+if (TBB_ARCH_PLATFORM)
+  foreach (dir IN LISTS TBB_PREFIX_PATH)
+    list(APPEND TBB_LIB_SEARCH_PATH ${dir}/${TBB_ARCH_PLATFORM}/lib)
+    list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/${TBB_ARCH_PLATFORM})
+  endforeach ()
+endif ()
+foreach (dir IN LISTS TBB_PREFIX_PATH)
+  foreach (prefix IN LISTS COMPILER_PREFIX)
+    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/intel64)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/intel64/${prefix})
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/intel64/lib)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/intel64/${prefix}/lib)
+    else ()
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia32)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia32/${prefix})
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia32/lib)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia32/${prefix}/lib)
+    endif ()
+  endforeach()
+endforeach ()
+# add general search paths
+foreach (dir IN LISTS TBB_PREFIX_PATH)
+  list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib ${dir}/Lib ${dir}/lib/tbb
+    ${dir}/Libs)
+  list(APPEND TBB_INC_SEARCH_PATH ${dir}/include ${dir}/Include
+    ${dir}/include/tbb)
+endforeach ()
+set(TBB_LIBRARY_NAMES tbb)
+get_debug_names(TBB_LIBRARY_NAMES)
+find_path(TBB_INCLUDE_DIR
+          NAMES tbb/tbb.h
+          HINTS ${TBB_INC_SEARCH_PATH})
+find_tbb_library_verifying_release_debug_locations(TBB_LIBRARY)
+make_library_set(TBB_LIBRARY)
+findpkg_finish(TBB tbb)
+#if we haven't found TBB no point on going any further
+if (NOT TBB_FOUND)
+  return()
+endif ()
+#=============================================================================
+# Look for TBB's malloc package
+set(TBB_MALLOC_LIBRARY_NAMES tbbmalloc)
+get_debug_names(TBB_MALLOC_LIBRARY_NAMES)
+find_path(TBB_MALLOC_INCLUDE_DIR
+          NAMES tbb/tbb.h
+          HINTS ${TBB_INC_SEARCH_PATH})
+find_tbb_library_verifying_release_debug_locations(TBB_MALLOC_LIBRARY)
+make_library_set(TBB_MALLOC_LIBRARY)
+findpkg_finish(TBB_MALLOC tbbmalloc)
+#=============================================================================
+# Look for TBB's malloc proxy package
+set(TBB_MALLOC_PROXY_LIBRARY_NAMES tbbmalloc_proxy)
+get_debug_names(TBB_MALLOC_PROXY_LIBRARY_NAMES)
+find_path(TBB_MALLOC_PROXY_INCLUDE_DIR
+          NAMES tbb/tbbmalloc_proxy.h
+          HINTS ${TBB_INC_SEARCH_PATH})
+find_tbb_library_verifying_release_debug_locations(TBB_MALLOC_PROXY_LIBRARY)
+make_library_set(TBB_MALLOC_PROXY_LIBRARY)
+findpkg_finish(TBB_MALLOC_PROXY tbbmalloc_proxy)
+#=============================================================================
+#parse all the version numbers from tbb
+if(NOT TBB_VERSION)
+  set(TBB_VERSION_FILE_PRIOR_TO_TBB_2021_1
+    "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h")
+  set(TBB_VERSION_FILE_AFTER_TBB_2021_1
+    "${TBB_INCLUDE_DIR}/oneapi/tbb/version.h")
+  if (EXISTS "${TBB_VERSION_FILE_PRIOR_TO_TBB_2021_1}")
+    set(TBB_VERSION_FILE "${TBB_VERSION_FILE_PRIOR_TO_TBB_2021_1}")
+  elseif (EXISTS "${TBB_VERSION_FILE_AFTER_TBB_2021_1}")
+    set(TBB_VERSION_FILE "${TBB_VERSION_FILE_AFTER_TBB_2021_1}")
+  else()
+    message(FATAL_ERROR "Found TBB installation: ${TBB_INCLUDE_DIR} "
+      "missing version header.")
+  endif()
+ #only read the start of the file
+ file(STRINGS
+      "${TBB_VERSION_FILE}"
+      TBB_VERSION_CONTENTS
+      REGEX "VERSION")
+  string(REGEX REPLACE
+    ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
+    TBB_VERSION_MAJOR "${TBB_VERSION_CONTENTS}")
+  string(REGEX REPLACE
+    ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"
+    TBB_VERSION_MINOR "${TBB_VERSION_CONTENTS}")
+  string(REGEX REPLACE
+        ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1"
+        TBB_INTERFACE_VERSION "${TBB_VERSION_CONTENTS}")
+  string(REGEX REPLACE
+        ".*#define TBB_COMPATIBLE_INTERFACE_VERSION ([0-9]+).*" "\\1"
+        TBB_COMPATIBLE_INTERFACE_VERSION "${TBB_VERSION_CONTENTS}")
+endif()

--- a/cmake/tbb.cmake
+++ b/cmake/tbb.cmake
@@ -1,0 +1,4 @@
+#
+# TBB support
+#
+find_package(TBB REQUIRED)


### PR DESCRIPTION
Moving from my [PR in PDAL](https://github.com/PDAL/PDAL/pull/3552) here.


>When using pdal in some applications that are intensively reading entwine dataset, it appears some already fetched data could be cached.
This could be done in many way, this implementation is one amongst many that could be improved in many ways.
The idea is to use a [thread safe LRU cache](https://github.com/tstarling/thread-safe-lru), build around TBB.
The plugin is merely a copy of `readers.ept` but caches `TilesContents` and all the hierarchy fetched as `NL::json`.